### PR TITLE
Fix the Docker orchestrator and add CI to test it

### DIFF
--- a/.github/scripts/check-db.py
+++ b/.github/scripts/check-db.py
@@ -1,0 +1,70 @@
+# LAPSE - Language-Agnostic subtitle synchronization engine
+# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+import os
+import sqlite3
+import sys
+
+SHIFT = -4200
+TOLERANCE = 250
+
+expected = {
+    "/media/Movies/Test Movie (2024)/Test Movie (2024).en.srt":
+        "/media/Movies/Test Movie (2024)/Test Movie (2024).mkv",
+    "/media/Movies/Scene.Release.2024.1080p.BluRay.x264-GRP/Subs/2_English.srt":
+        "/media/Movies/Scene.Release.2024.1080p.BluRay.x264-GRP/Scene.Release.2024.1080p.BluRay.x264-GRP.mkv",
+    "/media/TV/Show/Season 01/Show.S01E01.en.srt":
+        "/media/TV/Show/Season 01/Show.S01E01.1080p.WEB-DL.mkv",
+    "/media/TV/Show/Season 01/Show.S01E02.da.srt":
+        "/media/TV/Show/Season 01/Show.S01E02.1080p.WEB-DL.mkv",
+}
+
+if len(sys.argv) > 1 and sys.argv[1] == "extra":
+    expected["/media/TV/Show/Season 01/Subs/Show.S01E03.english.srt"] = \
+        "/media/TV/Show/Season 01/Show.S01E03.1080p.WEB-DL.mkv"
+
+rows = {}
+for sub, video, offset, confidence, status, backup in sqlite3.connect("/data/lapse.db").execute(
+        "SELECT srt_path, video_path, offset_ms, confidence, status, backup_path FROM sync_jobs"):
+    rows[sub] = (video, offset, confidence, status, backup)
+
+failures = []
+
+for sub, video in expected.items():
+    if sub not in rows:
+        failures.append("never synced: %s" % sub)
+        continue
+    got_video, offset, confidence, status, backup = rows[sub]
+    if got_video != video:
+        failures.append("%s was matched to the wrong video: %s" % (sub, got_video))
+    if status != "done":
+        failures.append("%s came back as %s" % (sub, status))
+    if offset is None or abs(offset - SHIFT) > TOLERANCE:
+        failures.append("%s got offset %s, expected around %d" % (sub, offset, SHIFT))
+    if confidence is None or confidence < 0.8:
+        failures.append("%s only scored %s" % (sub, confidence))
+    if not backup or not os.path.exists(backup):
+        failures.append("%s has no backup on disk" % sub)
+
+for sub in rows:
+    if sub not in expected:
+        failures.append("something got synced that should have been left alone: %s" % sub)
+
+if failures:
+    for line in failures:
+        print("FAIL:", line)
+    sys.exit(1)
+
+print("database looks right, %d pairs synced" % len(rows))

--- a/.github/scripts/make-media.sh
+++ b/.github/scripts/make-media.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# LAPSE - Language-Agnostic subtitle synchronization engine
+# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# Builds a library to test against, inside the image so it has ffmpeg.
+# The audio is eight bursts of band limited noise sitting in eight second
+# slots, which the voice detector picks up the same way it picks up speech.
+set -e
+
+SLOT=8
+LEAD=2
+BURSTS=8
+
+build_video() {
+    ffmpeg -v error -y -f lavfi -i "anoisesrc=color=pink:r=16000:d=3:a=0.6" \
+        -af "highpass=f=300,lowpass=f=3000,tremolo=f=5:d=0.9" /tmp/burst.wav
+
+    inputs=""
+    filters=""
+    chain=""
+    for i in $(seq 0 $((BURSTS - 1))); do
+        inputs="$inputs -i /tmp/burst.wav"
+        filters="$filters[$i:a]apad=whole_dur=$SLOT[a$i];"
+        chain="$chain[a$i]"
+    done
+
+    ffmpeg -v error -y $inputs -filter_complex \
+        "${filters}${chain}concat=n=$BURSTS:v=0:a=1,adelay=${LEAD}000|${LEAD}000,apad=pad_dur=2[out]" \
+        -map "[out]" -ar 16000 -ac 1 /tmp/audio.wav
+
+    ffmpeg -v error -y -f lavfi -i color=c=black:s=320x240:r=24 -i /tmp/audio.wav \
+        -c:v libx264 -preset ultrafast -pix_fmt yuv420p -c:a aac -shortest /tmp/video.mkv
+}
+
+write_srt() {
+    python3 -c "
+import sys
+path, shift = sys.argv[1], int(sys.argv[2])
+def ts(ms):
+    h = ms // 3600000; ms %= 3600000
+    m = ms // 60000; ms %= 60000
+    s = ms // 1000; ms %= 1000
+    return '%02d:%02d:%02d,%03d' % (h, m, s, ms)
+cues = []
+for i in range($BURSTS):
+    start = $LEAD * 1000 + i * $SLOT * 1000 + shift
+    cues.append('%d\n%s --> %s\nline %d\n' % (i + 1, ts(start), ts(start + 3000), i + 1))
+open(path, 'w').write('\n'.join(cues))
+" "$1" "$2"
+}
+
+build_video
+
+if [ "$1" = "extra" ]; then
+    # A release turning up while the watcher is already running
+    mkdir -p "/media/TV/Show/Season 01/Subs"
+    cp /tmp/video.mkv "/media/TV/Show/Season 01/Show.S01E03.1080p.WEB-DL.mkv"
+    write_srt "/media/TV/Show/Season 01/Subs/Show.S01E03.english.srt" 4200
+    chown -R 1000:1000 /media
+    echo "added a new episode"
+    exit 0
+fi
+
+mkdir -p "/media/Movies/Test Movie (2024)"
+cp /tmp/video.mkv "/media/Movies/Test Movie (2024)/Test Movie (2024).mkv"
+write_srt "/media/Movies/Test Movie (2024)/Test Movie (2024).en.srt" 4200
+
+# Subtitles in their own folder, the way a lot of releases ship
+mkdir -p "/media/Movies/Scene.Release.2024.1080p.BluRay.x264-GRP/Subs"
+cp /tmp/video.mkv "/media/Movies/Scene.Release.2024.1080p.BluRay.x264-GRP/Scene.Release.2024.1080p.BluRay.x264-GRP.mkv"
+write_srt "/media/Movies/Scene.Release.2024.1080p.BluRay.x264-GRP/Subs/2_English.srt" 4200
+
+# Two episodes side by side, each subtitle has to find its own one
+mkdir -p "/media/TV/Show/Season 01"
+cp /tmp/video.mkv "/media/TV/Show/Season 01/Show.S01E01.1080p.WEB-DL.mkv"
+cp /tmp/video.mkv "/media/TV/Show/Season 01/Show.S01E02.1080p.WEB-DL.mkv"
+write_srt "/media/TV/Show/Season 01/Show.S01E01.en.srt" 4200
+write_srt "/media/TV/Show/Season 01/Show.S01E02.da.srt" 4200
+
+# Things that should be left where they are
+mkdir -p "/media/TV/Show/Season 01/@eaDir" "/media/Movies/Orphan"
+write_srt "/media/TV/Show/Season 01/@eaDir/Show.S01E01.srt" 0
+write_srt "/media/Movies/Orphan/orphan.srt" 0
+
+chown -R 1000:1000 /media
+find /media -type f -exec touch -d "10 minutes ago" {} +
+echo "library ready"
+find /media -type f | sort

--- a/.github/scripts/smoke-docker.sh
+++ b/.github/scripts/smoke-docker.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# LAPSE - Language-Agnostic subtitle synchronization engine
+# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# Runs the image the way somebody would actually run it and checks that a
+# library full of out of sync subtitles comes out the other side corrected.
+set -e
+
+IMAGE=$1
+SCRIPTS=$(cd "$(dirname "$0")" && pwd)
+MEDIA=lapse-ci-media-$$
+DATA=lapse-ci-data-$$
+CONTAINER=lapse-ci-$$
+
+cleanup() {
+    docker rm -f $CONTAINER > /dev/null 2>&1 || true
+    docker volume rm $MEDIA $DATA > /dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+wait_for() {
+    text=$1
+    limit=${2:-180}
+    waited=0
+    while [ $waited -lt $limit ]; do
+        if docker logs $CONTAINER 2>&1 | grep -qF "$text"; then
+            return 0
+        fi
+        sleep 3
+        waited=$((waited + 3))
+    done
+    echo "FAIL: gave up waiting for: $text"
+    docker logs $CONTAINER
+    exit 1
+}
+
+docker volume create $MEDIA > /dev/null
+docker volume create $DATA > /dev/null
+
+echo "== building a library to work on"
+docker run --rm -v $MEDIA:/media -v "$SCRIPTS:/scripts:ro" --entrypoint /scripts/make-media.sh $IMAGE
+
+echo "== starting the container the way the compose file does"
+docker run -d --name $CONTAINER -v $MEDIA:/media -v $DATA:/data \
+    -e PUID=1000 -e PGID=1000 -e SCAN_INTERVAL=0 $IMAGE > /dev/null
+
+wait_for "Watching for new files..."
+docker logs $CONTAINER
+
+echo "== checking what it did"
+docker run --rm -v $DATA:/data -v $MEDIA:/media -v "$SCRIPTS:/scripts:ro" \
+    --entrypoint python3 $IMAGE /scripts/check-db.py
+
+if docker logs $CONTAINER 2>&1 | grep -q "@eaDir"; then
+    echo "FAIL: it went into @eaDir"
+    exit 1
+fi
+
+echo "== dropping a new episode in while it runs"
+docker run --rm -v $MEDIA:/media -v "$SCRIPTS:/scripts:ro" --entrypoint /scripts/make-media.sh $IMAGE extra
+wait_for "Show.S01E03.english.srt"
+wait_for "Done (nosplit)"
+sleep 5
+docker run --rm -v $DATA:/data -v $MEDIA:/media -v "$SCRIPTS:/scripts:ro" \
+    --entrypoint python3 $IMAGE /scripts/check-db.py extra
+
+echo "== everything the container writes belongs to the right user"
+docker run --rm -v $MEDIA:/media -v $DATA:/data --entrypoint sh $IMAGE -c '
+found=$(find /media /data ! -user 1000 -type f | head)
+if [ -n "$found" ]; then
+    echo "FAIL: these are not owned by 1000:"
+    echo "$found"
+    exit 1
+fi
+echo "all files owned by 1000"'
+
+echo "== stopping should be quick and clean"
+start=$(date +%s)
+docker stop $CONTAINER > /dev/null
+elapsed=$(($(date +%s) - start))
+if [ $elapsed -gt 8 ]; then
+    echo "FAIL: took ${elapsed}s to stop, it is not handling the signal"
+    exit 1
+fi
+if ! docker logs $CONTAINER 2>&1 | grep -q "Shutting down"; then
+    echo "FAIL: it did not shut down cleanly"
+    exit 1
+fi
+echo "stopped in ${elapsed}s"
+
+echo "== starting again should not redo finished work"
+# docker keeps the log from before the restart, so only look at what comes after
+before=$(docker logs $CONTAINER 2>&1 | wc -l)
+docker start $CONTAINER > /dev/null
+sleep 25
+if docker logs $CONTAINER 2>&1 | tail -n +$((before + 1)) | grep -q "Syncing:"; then
+    echo "FAIL: it synced something a second time"
+    docker logs $CONTAINER 2>&1 | tail -n +$((before + 1))
+    exit 1
+fi
+echo "nothing was done twice"
+
+echo "docker image looks good"

--- a/.github/scripts/smoke-engine.sh
+++ b/.github/scripts/smoke-engine.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+# LAPSE - Language-Agnostic subtitle synchronization engine
+# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# Syncs a subtitle against a reference subtitle with a shift we picked
+# ourselves, so we know exactly what the binary is supposed to come back with.
+set -e
+
+LAPSE=$(cd "$(dirname "$1")" && pwd)/$(basename "$1")
+SHIFT=4200
+WORK=$(mktemp -d)
+cd "$WORK"
+
+timestamp() {
+    printf "%02d:%02d:%02d,%03d" $(($1 / 3600000)) $(($1 % 3600000 / 60000)) $(($1 % 60000 / 1000)) $(($1 % 1000))
+}
+
+for i in $(seq 0 39); do
+    start=$((5000 + i * 7000))
+    end=$((start + 3000))
+    cue=$((i + 1))
+    printf "%d\n%s --> %s\nline %d\n\n" "$cue" "$(timestamp $start)" "$(timestamp $end)" "$cue" >> reference.srt
+    printf "%d\n%s --> %s\nline %d\n\n" "$cue" "$(timestamp $((start + SHIFT)))" "$(timestamp $((end + SHIFT)))" "$cue" >> late.srt
+done
+cp late.srt sidecar.srt
+
+echo "== a subtitle that is ${SHIFT}ms late"
+output=$("$LAPSE" reference.srt late.srt)
+echo "$output"
+
+if ! echo "$output" | grep -q -- "offset=-${SHIFT}ms"; then
+    echo "FAIL: expected offset=-${SHIFT}ms"
+    exit 1
+fi
+if [ ! -f late.srt.bak ]; then
+    echo "FAIL: no backup was written"
+    exit 1
+fi
+if [ "$(grep -m1 -- '-->' late.srt)" != "$(grep -m1 -- '-->' reference.srt)" ]; then
+    echo "FAIL: the corrected file does not line up with the reference"
+    exit 1
+fi
+
+echo "== writing a sidecar and leaving the original alone"
+"$LAPSE" reference.srt sidecar.srt --output fixed.srt --no-backup > /dev/null
+if [ ! -f fixed.srt ] || [ -f sidecar.srt.bak ]; then
+    echo "FAIL: --output or --no-backup did not do what it says"
+    exit 1
+fi
+if [ "$(grep -m1 -- '-->' sidecar.srt)" != "$(grep -m1 -- '-->' late.srt.bak)" ]; then
+    echo "FAIL: the input was touched when it should not have been"
+    exit 1
+fi
+
+echo "== a format the engine does not read"
+cp reference.srt unreadable.xyz
+if "$LAPSE" reference.srt unreadable.xyz > /dev/null 2>&1; then
+    echo "FAIL: an unreadable format should come back as an error"
+    exit 1
+fi
+
+echo "== an existing backup is never overwritten"
+echo "the original" > guarded.srt.bak
+cp late.srt.bak guarded.srt
+"$LAPSE" reference.srt guarded.srt > /dev/null
+if [ "$(cat guarded.srt.bak)" != "the original" ]; then
+    echo "FAIL: the first backup was overwritten"
+    exit 1
+fi
+
+cd /
+rm -rf "$WORK"
+echo "engine looks good"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,151 @@
+# LAPSE - Language-Agnostic subtitle synchronization engine
+# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+name: CI
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  engine:
+    name: Release binary (${{ matrix.arch }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            os: ubuntu-latest
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install build tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential autoconf automake libtool pkg-config \
+            nasm yasm libfftw3-dev zlib1g-dev
+
+      - name: Build FFmpeg 7.x static
+        run: |
+          wget -q https://ffmpeg.org/releases/ffmpeg-7.1.tar.xz
+          tar xf ffmpeg-7.1.tar.xz
+          cd ffmpeg-7.1
+          ./configure \
+            --prefix=/opt/ffmpeg \
+            --enable-static \
+            --disable-shared \
+            --disable-programs \
+            --disable-doc \
+            --disable-debug \
+            --disable-everything \
+            --enable-avformat \
+            --enable-avcodec \
+            --enable-avutil \
+            --enable-swresample \
+            --enable-demuxer=matroska,mov,avi,mp4,ogg,wav,flac,aac \
+            --enable-decoder=aac,ac3,eac3,mp3,flac,vorbis,opus,dca,truehd,pcm_s16le,pcm_s16be,pcm_s24le,pcm_f32le,pcm_f32be \
+            --enable-parser=aac,mp3,flac,vorbis,opus,ac3 \
+            --enable-protocol=file
+          make -j$(nproc)
+          sudo make install
+
+      - name: Verify FFmpeg static build
+        run: |
+          for lib in libavformat libavcodec libavutil libswresample; do
+            if [ ! -f "/opt/ffmpeg/lib/${lib}.a" ]; then
+              echo "Missing /opt/ffmpeg/lib/${lib}.a, static FFmpeg build failed"
+              exit 1
+            fi
+          done
+          ls -la /opt/ffmpeg/lib/*.a
+
+      - name: Build libfvad static
+        run: |
+          git clone https://github.com/dpirch/libfvad.git
+          cd libfvad
+          autoreconf -i
+          ./configure --prefix=/opt/libfvad --enable-static --disable-shared
+          make
+          sudo make install
+
+      - name: Build lapse
+        run: |
+          cd engine
+          g++ -O2 -std=c++20 \
+            -I/opt/ffmpeg/include \
+            -I/opt/libfvad/include \
+            -o lapse-linux-${{ matrix.arch }} \
+            main.cpp correlate.cpp decoder.cpp srt_parser.cpp write_subtitle.cpp \
+            -static-libgcc -static-libstdc++ \
+            /opt/ffmpeg/lib/libavformat.a \
+            /opt/ffmpeg/lib/libavcodec.a \
+            /opt/ffmpeg/lib/libswresample.a \
+            /opt/ffmpeg/lib/libavutil.a \
+            /opt/libfvad/lib/libfvad.a \
+            -Wl,-Bstatic -lfftw3 -Wl,-Bdynamic \
+            -lm -lpthread -lz -ldl
+
+      - name: Test the binary
+        run: engine/lapse-linux-${{ matrix.arch }} --formats && .github/scripts/smoke-engine.sh engine/lapse-linux-${{ matrix.arch }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lapse-linux-${{ matrix.arch }}
+          path: engine/lapse-linux-${{ matrix.arch }}
+
+  image:
+    name: Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build for both platforms the release publishes
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build for testing
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: false
+          load: true
+          tags: lapse:ci
+          cache-from: type=gha
+
+      - name: Test the engine inside the image
+        run: |
+          docker run --rm --entrypoint /app/lapse lapse:ci --formats
+          docker run --rm -v "$PWD/.github/scripts:/scripts:ro" --entrypoint /scripts/smoke-engine.sh lapse:ci /app/lapse
+
+      - name: Test the watcher inside the image
+        run: .github/scripts/smoke-docker.sh lapse:ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Built in C++ using FFmpeg for audio decoding, libfvad for voice activity detecti
 
 **OLS mode**
 
-Uses FFT cross-correlation across 15-minute chunks and fits a line through the per-chunk offsets using weighted linear regression. Handles both constant offset and linear drift from framerate mismatches. Less accurate than no-split for constant offsets but produces a slope and intercept that can correct gradual drift.
+For subtitles that drift, usually because they were timed for a different framerate than the video. It stretches the subtitle by each framerate ratio that actually gets shipped (23.976, 24, 25, 29.97 and the conversions between them), runs the no-split search for each one and keeps whichever ratio explained the most of the file.
+
+If none of them fit, it falls back to FFT cross-correlation across 15-minute chunks with a weighted linear regression through the per-chunk offsets, which can pick up a stretch that is not a standard ratio.
 
 **Split mode**
 
@@ -82,7 +84,35 @@ Sync with split mode for director's cuts or ad-break versions:
 
 The fourth argument is the split penalty. A value of 6 is a good default. Higher values produce fewer splits.
 
-### Docker (experimental)
+#### Output options
+
+By default LAPSE overwrites the subtitle file it was given and leaves a `.bak` next to it. Two flags change that:
+
+```
+--output <path>     write the corrected subtitle to <path> instead of overwriting the input
+--no-backup         do not create the .bak file
+```
+
+Together they cover the four ways a caller may want the output handled:
+
+| Result | Flags |
+|---|---|
+| Overwrite, keep a backup (default) | *neither flag* |
+| Overwrite, no backup | `--no-backup` |
+| Write a sidecar, leave the original alone | `--output out.srt --no-backup` |
+| Write a sidecar and back up the original | `--output out.srt` |
+
+```bash
+./lapse reference.srt danish.srt --output danish.synced.srt --no-backup
+```
+
+The flags may appear anywhere on the command line. An existing `.bak` is never overwritten, so the first backup stays the untouched original no matter how many times you run LAPSE on a file.
+
+#### Confidence
+
+Every run prints a confidence between 0 and 1 alongside the offset. It is the share of the subtitle file that ended up sitting on speech, so around 1.0 means every cue found its place and below roughly 0.5 means the two files probably do not belong together. LAPSE still writes the file -- the number is there so the caller can decide whether to keep the result.
+
+### Docker
 
 The Docker image includes the C++ binary and the Python file watcher. Point it at your media library and it will scan on startup then watch for new files.
 
@@ -97,14 +127,52 @@ services:
     environment:
       - MEDIA_ROOT=/media
       - DB_PATH=/data/lapse.db
-      - LAPSE_BIN=/app/lapse
+      - PUID=1000
+      - PGID=1000
 ```
 
 ```bash
 docker compose up -d
 ```
 
-LAPSE matches video files to subtitle files by filename similarity within the same directory. It handles the usual naming differences from scene releases reasonably well. The first run is worth watching with `docker compose logs -f lapse` to make sure matches look correct.
+Everything you mount gets scanned. To use more than one library, add another volume and list both paths:
+
+```yaml
+    volumes:
+      - /your/movies:/movies
+      - /your/tv:/tv
+    environment:
+      - MEDIA_ROOT=/movies,/tv
+```
+
+Set `PUID` and `PGID` to the user that owns your media. Without them the container runs as root and the files it writes end up owned by root.
+
+#### Settings
+
+| Variable | Default | What it does |
+|---|---|---|
+| `MEDIA_ROOT` | `/media` | Where to look. Comma separated for more than one library |
+| `DB_PATH` | `/data/lapse.db` | Where the record of finished work is kept |
+| `PUID` / `PGID` | unset | Run as this user and group |
+| `MODE` | `nosplit` | `nosplit`, `ols` or `split` |
+| `PENALTY` | `6` | Split penalty, only used in split mode |
+| `SCAN_INTERVAL` | `900` | Seconds between full rescans. `0` turns them off |
+| `MIN_CONFIDENCE` | `0` | Put the original back when a result scores below this. `0` keeps everything |
+| `MAX_ATTEMPTS` | `3` | How many times a failing pair is retried before it is left alone |
+| `TIMEOUT` | `1800` | Seconds a single sync may take |
+| `POLLING` | `0` | Set to `1` on network shares where file events do not arrive |
+
+#### Matching
+
+Subtitles are matched to video by filename inside the same folder. If the subtitles sit in their own folder, like the `Subs` folder a lot of releases ship with, the folder above is checked as well.
+
+Language and tag words such as `en`, `danish`, `forced` and `sdh` are ignored when names are compared, so a video can have several subtitle files matched to it at once. Episode numbers have to agree, so `S01E01` never picks up the subtitle for `S01E02`. When a folder holds one video, any subtitle in it belongs to that video.
+
+New files are picked up as they arrive. A file is left alone until it stops changing, so a download that is still being written is not touched. Full rescans catch anything the file events missed, which is what `SCAN_INTERVAL` and `POLLING` are for on network storage.
+
+Every sync is written to the database, so the same file is never done twice. Replacing a subtitle file with a new one gets it synced again.
+
+The first run is worth watching with `docker compose logs -f lapse` to check that the matches look right.
 
 ---
 
@@ -116,6 +184,8 @@ LAPSE matches video files to subtitle files by filename similarity within the sa
 **Subtitles:** `.srt`, `.ass`, `.ssa`, `.vtt`
 
 Planned to support most common video and subtitle formats.
+
+Run `lapse --formats` to print the subtitle formats your binary can read, one per line.
 
 ---
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     libfftw3-dev \
     g++ pkg-config \
     git automake autoconf libtool \
+    gosu \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/dpirch/libfvad.git /tmp/libfvad && \
@@ -32,13 +33,21 @@ RUN git clone https://github.com/dpirch/libfvad.git /tmp/libfvad && \
     ldconfig && \
     rm -rf /tmp/libfvad
 
+ENV PYTHONUNBUFFERED=1
+ENV MEDIA_ROOT=/media
+ENV DB_PATH=/data/lapse.db
+ENV LAPSE_BIN=/app/lapse
+
 WORKDIR /app
 COPY docker/requirements.txt .
 RUN pip3 install -r requirements.txt --break-system-packages
 COPY engine/correlate.cpp engine/correlate.h engine/decoder.cpp engine/decoder.h \
      engine/srt_parser.cpp engine/srt_parser.h engine/main.cpp \
-     engine/write_subtitle.cpp engine/write_subtitle.h .
+     engine/write_subtitle.cpp engine/write_subtitle.h ./
 RUN g++ -O2 -std=c++20 -o lapse main.cpp correlate.cpp decoder.cpp srt_parser.cpp write_subtitle.cpp \
     -lavcodec -lavformat -lavutil -lswresample -lfvad -lfftw3
 COPY docker/main.py .
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["python3", "main.py"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # LAPSE - Language-Agnostic subtitle synchronization engine
 # Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
 # This program is free software: you can redistribute it and/or modify
@@ -13,28 +14,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-services:
-  lapse:
-    container_name: lapse
-    image: ghcr.io/rs-jensen/lapse:latest
-    restart: always
-    ulimits:
-      core: 0
-    tmpfs:
-      - /tmp
-    volumes:
-      - ./data:/data
-      - /mnt/media:/media
-    environment:
-      - MEDIA_ROOT=/media
-      - DB_PATH=/data/lapse.db
-      - LAPSE_BIN=/app/lapse
-      - PUID=1000
-      - PGID=1000
-      - MODE=nosplit
-      - PENALTY=6
-      - SCAN_INTERVAL=900
-      - MIN_CONFIDENCE=0
-      - MAX_ATTEMPTS=3
-      - TIMEOUT=1800
-      - POLLING=0
+set -e
+
+if [ -n "$PUID" ] || [ -n "$PGID" ]; then
+    USER_ID=${PUID:-0}
+    GROUP_ID=${PGID:-0}
+    DB_DIR=$(dirname "${DB_PATH:-/data/lapse.db}")
+    mkdir -p "$DB_DIR"
+    chown -R "$USER_ID:$GROUP_ID" "$DB_DIR" 2>/dev/null || true
+    echo "Running as $USER_ID:$GROUP_ID"
+    exec gosu "$USER_ID:$GROUP_ID" "$@"
+fi
+
+exec "$@"

--- a/docker/main.py
+++ b/docker/main.py
@@ -14,21 +14,83 @@
 # along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 import os
+import re
+import queue
+import shutil
+import signal
 import sqlite3
 import subprocess
-import shutil
 import time
-from pathlib import Path
 from watchdog.observers import Observer
+from watchdog.observers.polling import PollingObserver
 from watchdog.events import FileSystemEventHandler
 
-DB_PATH    = os.environ.get("DB_PATH", "lapse.db")
-MEDIA_ROOT = os.environ.get("MEDIA_ROOT", "/media")
-LAPSE    = os.environ.get("LAPSE_BIN", "./lapse")
-VIDEO_EXTS = ('.mp4', '.mkv', '.avi')
+DB_PATH        = os.environ.get("DB_PATH", "lapse.db")
+MEDIA_ROOT     = os.environ.get("MEDIA_ROOT", "/media")
+LAPSE          = os.environ.get("LAPSE_BIN", "./lapse")
+MODE           = os.environ.get("MODE", "nosplit")
+PENALTY        = os.environ.get("PENALTY", "6")
+SCAN_INTERVAL  = int(os.environ.get("SCAN_INTERVAL", "900"))
+MIN_CONFIDENCE = float(os.environ.get("MIN_CONFIDENCE", "0"))
+MAX_ATTEMPTS   = int(os.environ.get("MAX_ATTEMPTS", "3"))
+TIMEOUT        = int(os.environ.get("TIMEOUT", "1800"))
+POLLING        = os.environ.get("POLLING", "0") == "1"
+
+MEDIA_ROOTS = [p.strip() for p in MEDIA_ROOT.split(",") if p.strip()]
+
+VIDEO_EXTS = {
+    ".mp4", ".mkv", ".avi", ".mov", ".m4v", ".ts", ".m2ts", ".mts", ".webm",
+    ".wmv", ".mpg", ".mpeg", ".flv", ".ogv", ".ogm", ".divx", ".vob", ".rmvb", ".3gp",
+}
+
+# Everything we know of as a subtitle, not everything the engine can read yet.
+# The engine tells us that part at startup and the rest is left alone
+SUBTITLE_EXTS = {
+    ".srt", ".ass", ".ssa", ".vtt", ".sub", ".idx", ".sup", ".smi", ".sami",
+    ".ttml", ".dfxp", ".sbv", ".mpl2", ".lrc", ".stl", ".scc", ".mcc", ".cap",
+}
+
+ENGINE_FORMATS = {".srt", ".ass", ".ssa", ".vtt"}
+
+SKIP_DIRS = {"@eaDir", "#recycle", "#snapshot", "lost+found", ".Trash", "@Recycle"}
+
+LANGUAGE_WORDS = {
+    "en", "eng", "english", "da", "dan", "dansk", "danish", "sv", "swe", "swedish",
+    "no", "nor", "nb", "norwegian", "fi", "fin", "finnish", "is", "isl", "icelandic",
+    "de", "ger", "deu", "german", "fr", "fre", "fra", "french", "es", "spa", "spanish",
+    "it", "ita", "italian", "nl", "dut", "nld", "dutch", "pt", "por", "portuguese",
+    "pl", "pol", "polish", "ru", "rus", "russian", "cs", "ces", "czech", "tr", "tur",
+    "turkish", "ar", "ara", "arabic", "zh", "chi", "chinese", "ja", "jpn", "japanese",
+    "ko", "kor", "korean", "hu", "hun", "hungarian", "ro", "ron", "romanian", "el",
+    "ell", "greek", "he", "heb", "hebrew", "hi", "hin", "hindi", "th", "tha", "thai",
+    "forced", "sdh", "cc", "hearing", "impaired", "full", "default", "sub", "subs",
+    "subtitle", "subtitles", "srt", "track",
+}
+
+jobs = queue.Queue()
+running = True
+
+
+def engine_formats():
+    try:
+        result = subprocess.run([LAPSE, "--formats"], capture_output=True, text=True, timeout=30)
+        found = set()
+        for word in result.stdout.split():
+            if word.startswith("."):
+                found.add(word.lower())
+        if found:
+            return found
+        print("Engine did not answer --formats, going with the formats we know about")
+    except Exception as e:
+        print("Could not ask the engine which formats it reads:", e)
+    return ENGINE_FORMATS
 
 
 def init_db():
+    directory = os.path.dirname(DB_PATH)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
     conn = sqlite3.connect(DB_PATH)
     conn.execute("""
         CREATE TABLE IF NOT EXISTS sync_jobs (
@@ -38,6 +100,10 @@ def init_db():
             backup_path TEXT,
             slope REAL,
             intercept_ms REAL,
+            offset_ms REAL,
+            confidence REAL,
+            srt_mtime REAL,
+            attempts INTEGER DEFAULT 0,
             status TEXT DEFAULT 'pending',
             created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
         )
@@ -46,150 +112,391 @@ def init_db():
         CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_jobs_video_srt
         ON sync_jobs(video_path, srt_path)
     """)
-    for col in [("slope", "REAL"), ("intercept_ms", "REAL")]:
+    for name, kind in [("slope", "REAL"), ("intercept_ms", "REAL"), ("offset_ms", "REAL"),
+                        ("confidence", "REAL"), ("srt_mtime", "REAL"), ("attempts", "INTEGER DEFAULT 0")]:
         try:
-            conn.execute(f"ALTER TABLE sync_jobs ADD COLUMN {col[0]} {col[1]}")
-        except:
+            conn.execute("ALTER TABLE sync_jobs ADD COLUMN %s %s" % (name, kind))
+        except Exception:
             pass
     conn.commit()
     return conn
 
 
 def normalize(name):
-    for ch in "._-":
+    for ch in "._-[]()+'":
         name = name.replace(ch, " ")
     return set(name.lower().split())
 
 
-def find_pairs(path):
-    pairs = []
+def subtitle_tokens(base):
+    return normalize(base) - LANGUAGE_WORDS
+
+
+def episode_tag(name):
+    match = re.search(r"[sS](\d{1,2})[ ._-]?[eE](\d{1,3})", name)
+    if match:
+        return (int(match.group(1)), int(match.group(2)))
+    match = re.search(r"(?<!\d)(\d{1,2})x(\d{2})(?!\d)", name)
+    if match:
+        return (int(match.group(1)), int(match.group(2)))
+    return None
+
+
+def match_video(sbase, videos):
+    tokens = subtitle_tokens(sbase)
+    stag = episode_tag(sbase)
+    best, best_score = None, 0.0
+    usable = []
+
+    for vbase, vpath in videos:
+        vtag = episode_tag(vbase)
+        # Two different episodes in one folder share nearly every other word,
+        # so a tag that disagrees settles it before we look at anything else
+        if stag and vtag and stag != vtag:
+            continue
+        usable.append((vbase, vpath))
+
+        vtokens = normalize(vbase)
+        if not vtokens:
+            continue
+        score = len(vtokens & tokens) / len(vtokens)
+        if score > best_score:
+            best_score = score
+            best = vpath
+
+    if best and best_score >= 0.5:
+        return best
+    # Nothing lined up by name, but if only one video can belong to it anyway
+    # then the subtitle is for that one
+    if len(usable) == 1:
+        return usable[0][1]
+    return None
+
+
+def scan(path):
+    videos = {}
+    subtitles = {}
 
     for root, dirs, files in os.walk(path):
-        videos = []
-        srts = []
+        dirs[:] = [d for d in dirs if d not in SKIP_DIRS and not d.startswith(".")]
 
         for filename in files:
-            if filename.startswith("._"):
+            if filename.startswith("."):
                 continue
+            base, ext = os.path.splitext(filename)
+            ext = ext.lower()
             full_path = os.path.join(root, filename)
-            base = os.path.splitext(filename)[0]
 
-            if filename.lower().endswith(VIDEO_EXTS):
-                videos.append((base, full_path))
-            elif filename.lower().endswith('.srt'):
-                srts.append((base, full_path))
+            if ext in VIDEO_EXTS:
+                videos.setdefault(root, []).append((base, full_path))
+            elif ext in SUBTITLE_EXTS:
+                subtitles.setdefault(root, []).append((base, full_path))
 
-        for vbase, vpath in videos:
-            best, best_score = None, 0
-            for sbase, spath in srts:
-                score = len(normalize(vbase) & normalize(sbase))
-                if score > best_score:
-                    best_score = score
-                    best = spath
+    return videos, subtitles
 
-            if best and best_score >= 3:
-                print(f"Matched: {vpath} -> {best}")
-                pairs.append((vpath, best))
-            else:
-                print(f"No srt match for: {vpath}")
+
+def videos_in(directory):
+    found = []
+    try:
+        for filename in sorted(os.listdir(directory)):
+            if filename.startswith("."):
+                continue
+            base, ext = os.path.splitext(filename)
+            if ext.lower() in VIDEO_EXTS:
+                found.append((base, os.path.join(directory, filename)))
+    except OSError:
+        pass
+    return found
+
+
+def find_pairs(path, verbose=False):
+    videos, subtitles = scan(path)
+    pairs = []
+
+    for directory in sorted(subtitles):
+        candidates = videos.get(directory)
+        # Scene releases drop the subtitles in a Subs folder beside the video
+        if not candidates:
+            candidates = videos_in(os.path.dirname(directory))
+
+        for sbase, spath in subtitles[directory]:
+            video = match_video(sbase, candidates) if candidates else None
+            if video:
+                pairs.append((video, spath))
+            elif verbose:
+                print("No video match for:", spath)
 
     return pairs
 
-def already_processed(conn, video_path, srt_path):
+
+def wait_stable(path):
+    # A file that is still being copied in gives us half a video, so leave it
+    # alone until nothing has touched it for a while
+    for _ in range(60):
+        if not running:
+            return False
+        try:
+            info = os.stat(path)
+        except OSError:
+            return False
+        if info.st_size > 0 and time.time() - info.st_mtime > 30:
+            return True
+        time.sleep(2)
+    return False
+
+
+def file_mtime(path):
+    try:
+        return os.path.getmtime(path)
+    except OSError:
+        return None
+
+
+def previous_job(conn, video_path, srt_path):
     cur = conn.execute(
-        "SELECT 1 FROM sync_jobs WHERE video_path = ? AND srt_path = ? AND status = 'done' LIMIT 1",
+        "SELECT status, attempts, srt_mtime FROM sync_jobs WHERE video_path = ? AND srt_path = ?",
         (video_path, srt_path)
     )
-    return cur.fetchone() is not None
+    return cur.fetchone()
+
+
+def needs_work(row, mtime):
+    if row is None:
+        return True
+
+    status, attempts, srt_mtime = row
+    # Somebody replaced the subtitle since we last wrote it, so it is a new job
+    if mtime is not None and srt_mtime is not None and abs(mtime - srt_mtime) > 1:
+        return True
+    if status in ("done", "lowconf"):
+        return False
+    return (attempts or 0) < MAX_ATTEMPTS
+
+
+def parse_output(output):
+    values = {}
+    for key, value in re.findall(r"(\w+)=(-?[\d.]+)", output):
+        try:
+            values[key] = float(value)
+        except ValueError:
+            pass
+    return values
 
 
 def run_sync(video_path, srt_path):
-    srt = Path(srt_path)
-    backup_path = srt.with_suffix(".srt.bak")
-    shutil.copy2(srt, backup_path)
+    command = [LAPSE, video_path, srt_path, MODE]
+    if MODE == "split":
+        command.append(PENALTY)
 
-    result = subprocess.run(
-        [LAPSE, video_path, srt_path],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-    print(result.stdout.strip())
-    return str(backup_path)
+    result = subprocess.run(command, capture_output=True, text=True, timeout=TIMEOUT)
+    output = (result.stdout or "").strip()
+    if output:
+        print(output)
+
+    if result.returncode != 0:
+        message = (result.stderr or "").strip()
+        raise RuntimeError(message or "lapse exited with %d" % result.returncode)
+
+    return parse_output(output)
 
 
-
-def save_result(conn, video_path, srt_path, backup_path, slope, intercept, status="done"):
-    intercept_ms = intercept * 1000 if intercept is not None else None
+def save_result(conn, video_path, srt_path, backup_path, values, attempts, status):
     conn.execute(
         """
         INSERT OR REPLACE INTO sync_jobs
-        (video_path, srt_path, backup_path, slope, intercept_ms, status)
-        VALUES (?, ?, ?, ?, ?, ?)
+        (video_path, srt_path, backup_path, slope, intercept_ms, offset_ms, confidence, srt_mtime, attempts, status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
-        (video_path, srt_path, backup_path, slope, intercept_ms, status)
+        (
+            video_path,
+            srt_path,
+            backup_path,
+            values.get("slope"),
+            values.get("intercept") * 1000 if values.get("intercept") is not None else None,
+            values.get("offset", values.get("base")),
+            values.get("confidence"),
+            file_mtime(srt_path),
+            attempts,
+            status,
+        )
     )
     conn.commit()
 
 
 def process(conn, video_path, srt_path):
-    if already_processed(conn, video_path, srt_path):
-        print(f"Skipping: {video_path}")
+    ext = os.path.splitext(srt_path)[1].lower()
+    if ext not in ENGINE_FORMATS:
+        return "unsupported"
+
+    row = previous_job(conn, video_path, srt_path)
+    if not needs_work(row, file_mtime(srt_path)):
+        return "skipped"
+
+    attempts = (row[1] or 0) + 1 if row else 1
+
+    if not wait_stable(video_path) or not wait_stable(srt_path):
+        print("Still being written, leaving it for the next scan:", srt_path)
+        return "busy"
+
+    print("Syncing:", srt_path)
+    print("      to:", video_path)
+    try:
+        values = run_sync(video_path, srt_path)
+    except Exception as e:
+        print("Failed:", srt_path, "->", e)
+        save_result(conn, video_path, srt_path, None, {}, attempts, "failed")
+        return "failed"
+
+    backup_path = srt_path + ".bak"
+    if not os.path.exists(backup_path):
+        backup_path = None
+
+    status = "done"
+    confidence = values.get("confidence")
+    if MIN_CONFIDENCE > 0 and confidence is not None and confidence < MIN_CONFIDENCE and backup_path:
+        shutil.copy2(backup_path, srt_path)
+        print("Confidence %.2f is under %.2f, put the original back: %s" % (confidence, MIN_CONFIDENCE, srt_path))
+        status = "lowconf"
+
+    save_result(conn, video_path, srt_path, backup_path, values, attempts, status)
+    return status
+
+
+def run_scan(conn, path, verbose=False):
+    if not os.path.isdir(path):
         return
 
-    print(f"Processing: {video_path}")
-    try:
-        backup_path = run_sync(video_path, srt_path)
-        save_result(conn, video_path, srt_path, backup_path, None, None)
-    except Exception as e:
-        print(f"Failed: {video_path} -> {e}")
-        save_result(conn, video_path, srt_path, None, None, None, status="failed")
+    unsupported = 0
+    for video, subtitle in find_pairs(path, verbose):
+        if not running:
+            return
+        if process(conn, video, subtitle) == "unsupported":
+            unsupported += 1
 
-
+    if unsupported:
+        print("Left", unsupported, "subtitles alone, the engine does not read those formats yet")
 
 
 class MediaHandler(FileSystemEventHandler):
-    def __init__(self, conn):
-        self.conn = conn
+    def interesting(self, path):
+        name = os.path.basename(path)
+        if name.startswith("."):
+            return False
+        ext = os.path.splitext(name)[1].lower()
+        return ext in VIDEO_EXTS or ext in SUBTITLE_EXTS
+
+    def queue(self, path, is_directory):
+        if is_directory:
+            jobs.put(path)
+        elif self.interesting(path):
+            jobs.put(os.path.dirname(path))
 
     def on_created(self, event):
-        if event.is_directory:
+        self.queue(event.src_path, event.is_directory)
+
+    def on_moved(self, event):
+        self.queue(event.dest_path, event.is_directory)
+
+    def on_closed(self, event):
+        self.queue(event.src_path, event.is_directory)
+
+
+def start_watching():
+    handler = MediaHandler()
+    observer = PollingObserver() if POLLING else Observer()
+    watched = 0
+
+    for root in MEDIA_ROOTS:
+        if not os.path.isdir(root):
+            print("Cannot watch, it is not mounted:", root)
+            continue
+        try:
+            observer.schedule(handler, root, recursive=True)
+            watched += 1
+        except OSError as e:
+            print("Cannot watch", root, "->", e)
+
+    if not watched:
+        print("Watching nothing, falling back to rescans only")
+        return None
+
+    observer.start()
+    return observer
+
+
+def settle(seconds):
+    for _ in range(seconds):
+        if not running:
             return
-        if event.src_path.endswith(('.srt', '.bak')):
-            return
-        
-        directory = os.path.dirname(event.src_path)
-        now = time.time()
-        if _last_processed.get(directory, 0) > now - 60:
-            return
-        _last_processed[directory] = now
-        
-        time.sleep(5)
-        conn = sqlite3.connect(DB_PATH)
-        pairs = find_pairs(directory)
-        for video, srt in pairs:
-            process(conn, video, srt)
-        conn.close()
+        time.sleep(1)
+
+
+def take_pending():
+    try:
+        first = jobs.get(timeout=5)
+    except queue.Empty:
+        return set()
+    if not running:
+        return set()
+
+    # A release lands as a pile of files, so let the rest of them turn up
+    # before we go and look at the folder
+    settle(10)
+    directories = {first}
+    while True:
+        try:
+            directories.add(jobs.get_nowait())
+        except queue.Empty:
+            break
+    directories.discard(None)
+    return directories
+
+
+# The queue is what the loop sits and waits on, so put something in it to
+# get out of that wait straight away instead of sitting out the timeout
+def stop(signum, frame):
+    global running
+    running = False
+    jobs.put(None)
 
 
 def main():
-    conn = init_db()
+    global ENGINE_FORMATS, SUBTITLE_EXTS
 
-    for video, srt in find_pairs(MEDIA_ROOT):
-        process(conn, video, srt)
+    signal.signal(signal.SIGTERM, stop)
+    signal.signal(signal.SIGINT, stop)
+
+    ENGINE_FORMATS = engine_formats()
+    SUBTITLE_EXTS = SUBTITLE_EXTS | ENGINE_FORMATS
+    print("Engine reads:", " ".join(sorted(ENGINE_FORMATS)))
+    print("Library:", ", ".join(MEDIA_ROOTS))
+
+    conn = init_db()
+    observer = start_watching()
+
+    for root in MEDIA_ROOTS:
+        if not os.path.isdir(root):
+            print("Not mounted, nothing to scan there:", root)
+            continue
+        run_scan(conn, root, verbose=True)
+    last_scan = time.time()
 
     print("Watching for new files...")
-    handler = MediaHandler(conn)
-    observer = Observer()
-    observer.schedule(handler, MEDIA_ROOT, recursive=True)
-    observer.start()
+    while running:
+        for directory in take_pending():
+            if not running:
+                break
+            run_scan(conn, directory, verbose=True)
 
-    try:
-        while True:
-            time.sleep(10)
-    except KeyboardInterrupt:
+        if running and SCAN_INTERVAL and time.time() - last_scan > SCAN_INTERVAL:
+            for root in MEDIA_ROOTS:
+                run_scan(conn, root)
+            last_scan = time.time()
+
+    print("Shutting down")
+    if observer:
         observer.stop()
-    observer.join()
+        observer.join()
     conn.close()
 
 

--- a/engine/correlate.cpp
+++ b/engine/correlate.cpp
@@ -16,24 +16,32 @@
 #include "correlate.h"
 
 // slope og intercept for y = slope*x + intercept
-std::pair<double, double> linear_regression(std::vector<double> x, std::vector<double> y, std::vector<double> w) {
+std::pair<double, double> linear_regression(const std::vector<double>& x, const std::vector<double>& y, const std::vector<double>& w) {
     double sw = 0, swx = 0 , swy = 0, swxx = 0, swxy = 0;
-    for (int i = 0; i < x.size(); i++) {
+    for (int i = 0; i < (int)x.size(); i++) {
         sw   += w[i];
         swx  += w[i] * x[i];
         swy  += w[i] * y[i];
         swxx += w[i] * x[i] * x[i];
         swxy += w[i] * x[i] * y[i];
     }
-    double slope = (sw*swxy - swx*swy) / (sw*swxx - swx*swx);
+
+    // One usable chunk cannot hold a line - fall back to a flat offset instead
+    // of dividing by zero and writing NaN into every timestamp
+    double denom = sw*swxx - swx*swx;
+    if (sw <= 0) return {0.0, 0.0};
+    if (std::abs(denom) < 1e-9) return {0.0, swy / sw};
+
+    double slope = (sw*swxy - swx*swy) / denom;
     double intercept = (swy - slope*swx) / sw;
     return {slope, intercept};
 }
 
-std::pair<double, double> fft_crosscorrelate(std::vector<int> activity_profile, std::vector<int> srt_profile) {
+std::pair<double, double> fft_crosscorrelate(const std::vector<int>& activity_profile, const std::vector<int>& srt_profile) {
     int padded = 262144;
     int chunk_size = 90000;
     int half = padded / 2 + 1;
+    int max_lag = MAX_OFFSET_MS / 10;   // profiles hold one entry per 10ms
 
     std::vector<double> t_vals, delta_vals, weights;
     int chunk_number = 0;
@@ -56,15 +64,26 @@ std::pair<double, double> fft_crosscorrelate(std::vector<int> activity_profile, 
     for (int chunks = 45000; chunks + chunk_size <= (int)activity_profile.size(); chunks += chunk_size) {
         chunk_number++;
 
+        // Both profiles are just ones and zeros so they carry a big constant
+        // term. Taking the mean out first stops the correlation from mostly
+        // measuring how much talking there is and gives a peak worth finding
+        double a_mean = 0, b_mean = 0;
+        for (int i = 0; i < chunk_size; ++i) {
+            a_mean += activity_profile[chunks + i];
+            if (chunks + i < (int)srt_profile.size()) b_mean += srt_profile[chunks + i];
+        }
+        a_mean /= chunk_size;
+        b_mean /= chunk_size;
+
         // Fill activity buffer then full the rest with zeros
         for (int i = 0; i < padded; ++i)
-            activity_buf[i] = (i < chunk_size) ? activity_profile[chunks + i] : 0.0;
+            activity_buf[i] = (i < chunk_size) ? activity_profile[chunks + i] - a_mean : 0.0;
 
         // Fill srt buffer same window then zeros
         for (int i = 0; i < padded; ++i)
-            srt_buf[i] = (i < chunk_size && chunks + i < (int)srt_profile.size()) ? srt_profile[chunks + i] : 0.0;
+            srt_buf[i] = (i < chunk_size && chunks + i < (int)srt_profile.size()) ? srt_profile[chunks + i] - b_mean : 0.0;
 
-  
+
         fftw_execute(plan_activity);
         fftw_execute(plan_srt);
 
@@ -85,38 +104,43 @@ std::pair<double, double> fft_crosscorrelate(std::vector<int> activity_profile, 
         for (int i = 0; i < padded; ++i)
             corr_out[i] /= padded;
 
-        // Find peak and second best peak
+        // Find the peak, only looking at lags we would actually believe
         double best_val = -std::numeric_limits<double>::infinity();
-        double second_val = -std::numeric_limits<double>::infinity();
-        int best_idx = 0;
+        int best_lag = 0;
 
         for (int i = 0; i < padded; ++i) {
+            int lag = (i < padded / 2) ? i : i - padded;
+            if (std::abs(lag) > max_lag) continue;
             if (corr_out[i] > best_val) {
                 best_val = corr_out[i];
-                best_idx = i;
-            } else if (corr_out[i] > second_val) {
-                second_val = corr_out[i];
+                best_lag = lag;
             }
         }
 
+        // The runner up has to come from somewhere else entirely. Taking the
+        // bin next to the peak told us nothing - it is always nearly as high,
+        // so every chunk came out with a sharpness of about 1
+        double second_val = -std::numeric_limits<double>::infinity();
+        for (int i = 0; i < padded; ++i) {
+            int lag = (i < padded / 2) ? i : i - padded;
+            if (std::abs(lag) > max_lag) continue;
+            if (std::abs(lag - best_lag) < 100) continue;   // skip a second either side
+            if (corr_out[i] > second_val) second_val = corr_out[i];
+        }
 
-        //Convert index to offset in ms
-        //Positive offsets index 0 to chunk_size-1
-        //Negative offsets index padded-chunk_size to padded-1
-        double offset_ms;
-
-        if (best_idx < padded / 2)
-            offset_ms = best_idx * 10.0;
-        else
-            offset_ms = (best_idx - padded) * 10.0;
-
-
-        double sharpness = best_val / second_val;
+        double offset_ms = best_lag * 10.0;
+        double sharpness = (second_val > 0) ? best_val / second_val : 0.0;
 
         std::cout << "t_" << chunk_number << " offset: " << offset_ms << "ms\n";
         std::cout << "Sharpness_" << chunk_number << ": " << sharpness << '\n';
 
-        t_vals.push_back((chunk_number - 0.5) * 900);
+        // A chunk that did not really lock onto anything only drags the line
+        // around, so leave it out instead of weighting it
+        if (sharpness < 1.05) continue;
+
+        // Time of the middle of this chunk in seconds. The chunks start seven
+        // and a half minutes in, which the old chunk_number*900 forgot about
+        t_vals.push_back((chunks + chunk_size / 2) * 0.01);
         delta_vals.push_back(offset_ms / 1000.0);
         weights.push_back(sharpness);
     }
@@ -147,35 +171,47 @@ One offset in ms
 weight function pr span par
 */
 
-int score_calculator(std::vector<std::pair<int, int>> read_srt, std::vector<std::pair<int, int>> reference_spans, int x) {
-    int score = 0;
+double score_calculator(const std::vector<std::pair<int, int>>& read_srt, const std::vector<std::pair<int, int>>& reference_spans, int x) {
+    double score = 0;
     int n = 0;
     int k = 0;
 
-    while (k < read_srt.size() && n < reference_spans.size()) {
+    while (k < (int)reference_spans.size() && n < (int)read_srt.size()) {
         int overlap = std::max(0, std::min(reference_spans[k].second, read_srt[n].second + x) - std::max(reference_spans[k].first, read_srt[n].first + x));
         int min_length = std::min(reference_spans[k].second - reference_spans[k].first, read_srt[n].second - read_srt[n].first);
-        double iscore = (double)overlap / min_length;
-
         int max_length = std::max(reference_spans[k].second - reference_spans[k].first, read_srt[n].second - read_srt[n].first);
-        float w = min_length / max_length;
 
-        score += iscore * w;
+        if (min_length > 0) {
+            double iscore = (double)overlap / min_length;
+            double w = (double)min_length / max_length;
+            score += iscore * w;
+        }
+
         if (reference_spans[k].second < read_srt[n].second + x)
             k += 1;
-        else 
+        else
             n +=1;
     }
     return score;
 }
 
-int best_offset(std::vector<std::pair<int, int>> read_srt, std::vector<std::pair<int, int>> reference_spans) {
+// Slides the subtitle spans over the reference and returns the offset where
+// they overlap best, together with how much of the file that offset explains
+std::pair<int, double> best_offset(const std::vector<std::pair<int, int>>& read_srt, const std::vector<std::pair<int, int>>& reference_spans) {
     std::vector<std::pair<int, float>> slope_changes;
 
-    for (int k = 0; k < reference_spans.size(); k++){
-        for (int n = 0; n < read_srt.size(); n++) {
+    for (int k = 0; k < (int)reference_spans.size(); k++){
+        for (int n = 0; n < (int)read_srt.size(); n++) {
+            // This pair can only ever meet somewhere between these two offsets,
+            // so skip it when that whole stretch is further out than we search
+            int reach_lo = reference_spans[k].first - read_srt[n].second;
+            int reach_hi = reference_spans[k].second - read_srt[n].first;
+            if (reach_hi < -MAX_OFFSET_MS || reach_lo > MAX_OFFSET_MS) continue;
+
             int min_length = std::min(reference_spans[k].second - reference_spans[k].first, read_srt[n].second - read_srt[n].first);
             int max_length = std::max(reference_spans[k].second - reference_spans[k].first, read_srt[n].second - read_srt[n].first);
+            if (min_length <= 0) continue;
+
             float w = (float)min_length / max_length;
             float slope = w / (float)min_length;
 
@@ -183,13 +219,13 @@ int best_offset(std::vector<std::pair<int, int>> read_srt, std::vector<std::pair
             if (max_length == reference_spans[k].second - reference_spans[k].first) {
                 int sig2 = reference_spans[k].first - read_srt[n].first;
                 int sig3 = reference_spans[k].second - read_srt[n].second;
-                
+
                 slope_changes.push_back({sig2, -slope});
                 slope_changes.push_back({sig3, -slope});
             } else {
                 int sig2 = reference_spans[k].second - read_srt[n].second;
                 int sig3 = reference_spans[k].first - read_srt[n].first;
-                
+
                 slope_changes.push_back({sig2, -slope});
                 slope_changes.push_back({sig3, -slope});
             }
@@ -201,30 +237,72 @@ int best_offset(std::vector<std::pair<int, int>> read_srt, std::vector<std::pair
 
     std::sort(slope_changes.begin(), slope_changes.end());
 
+    // These have to be doubles. The slopes are fractions of a millisecond and
+    // adding them to a long threw every one of them away, so the score never
+    // moved off zero and the answer was always an offset of 0
     int  sig_last = 0;
-    long fvalue = 0;
-    long fmax = 0;
-    long current_slope = 0;
-    int best_offset = 0;
-    for (int i = 0; i < slope_changes.size(); i++) {
+    double fvalue = 0;
+    double fmax = 0;
+    double current_slope = 0;
+    int best = 0;
+    for (int i = 0; i < (int)slope_changes.size(); i++) {
         fvalue += current_slope * (slope_changes[i].first - sig_last);
-        if (fvalue > fmax) {
+        if (fvalue > fmax && std::abs(slope_changes[i].first) <= MAX_OFFSET_MS) {
             fmax = fvalue;
-            best_offset = slope_changes[i].first;
+            best = slope_changes[i].first;
         }
         sig_last = slope_changes[i].first;
         current_slope += slope_changes[i].second;
     }
-    return best_offset;
+
+    // A cue that lands right on top of a reference span is worth 1, so this
+    // reads as the share of the subtitle file that ended up on speech
+    double confidence = read_srt.empty() ? 0.0 : fmax / read_srt.size();
+    if (confidence > 1.0) confidence = 1.0;
+
+    return {best, confidence};
 }
 
-std::vector<float> score_curve(std::pair<int,int> span, std::vector<std::pair<int,int>> reference_spans) {
-    std::vector<std::pair<int, float>> slope_changes;
-    std::vector<float> score_curve;
+// Stretches the subtitle by each framerate ratio in turn and keeps whichever
+// one lines up best. Measuring the drift chunk by chunk never really worked 
+// a quarter of an hour of film drifts more than half a minute at 4 percent, so
+// there is no single lag that fits the chunk and the peak just smears out
+std::tuple<double, int, double> best_framerate(const std::vector<std::pair<int, int>>& read_srt, const std::vector<std::pair<int, int>>& reference_spans) {
+    double best_ratio = 1.0;
+    int best_shift = 0;
+    double best_confidence = -1;
 
-    for (int k = 0; k < reference_spans.size(); k++) {
+    for (double ratio : FRAMERATE_RATIOS) {
+        std::vector<std::pair<int, int>> scaled;
+        scaled.reserve(read_srt.size());
+        for (auto& s : read_srt)
+            scaled.push_back({(int)(s.first * ratio), (int)(s.second * ratio)});
+
+        auto [offset, confidence] = best_offset(scaled, reference_spans);
+        std::cout << "ratio " << ratio << ": offset=" << offset << "ms confidence=" << confidence << '\n';
+
+        if (confidence > best_confidence) {
+            best_confidence = confidence;
+            best_ratio = ratio;
+            best_shift = offset;
+        }
+    }
+    return {best_ratio, best_shift, best_confidence};
+}
+
+//  Same idea as best_offset but for a single span, and instead of the best
+// offset we keep the whole score for every offset in the window. Sampling it
+// every 10ms rather than every millisecond is what makes split mode fit in
+//memory the old per millisecond version needed gigabytes for a film
+std::vector<double> score_curve(const std::pair<int,int>& span, const std::vector<std::pair<int,int>>& reference_spans, int lo, int hi, int step) {
+    std::vector<std::pair<int, float>> slope_changes;
+    std::vector<double> curve;
+
+    for (int k = 0; k < (int)reference_spans.size(); k++) {
         int min_length = std::min(reference_spans[k].second - reference_spans[k].first, span.second - span.first);
         int max_length = std::max(reference_spans[k].second - reference_spans[k].first, span.second - span.first);
+        if (min_length <= 0) continue;
+
         float w = (float)min_length / max_length;
         float slope = w / (float)min_length;
 
@@ -232,13 +310,13 @@ std::vector<float> score_curve(std::pair<int,int> span, std::vector<std::pair<in
         if (max_length == reference_spans[k].second - reference_spans[k].first) {
             int sig2 = reference_spans[k].first - span.first;
             int sig3 = reference_spans[k].second - span.second;
-                
+
             slope_changes.push_back({sig2, -slope});
             slope_changes.push_back({sig3, -slope});
         } else {
             int sig2 = reference_spans[k].second - span.second;
             int sig3 = reference_spans[k].first - span.first;
-                
+
             slope_changes.push_back({sig2, -slope});
             slope_changes.push_back({sig3, -slope});
         }
@@ -249,72 +327,92 @@ std::vector<float> score_curve(std::pair<int,int> span, std::vector<std::pair<in
 
     std::sort(slope_changes.begin(), slope_changes.end());
 
-    float omin = reference_spans.front().first - span.second;
-    float omax = reference_spans.back().second - span.first;
-    long current_slope = 0;
-    long fvalue = 0;
-    int j = 0;
-    for (int i = omin; i < omax; i++) {
-        while (j < slope_changes.size() && slope_changes[j].first == i) {
+    curve.reserve((hi - lo) / step + 1);
+    double fvalue = 0;
+    double current_slope = 0;
+    int sig_last = slope_changes.empty() ? lo : slope_changes[0].first;
+    size_t j = 0;
+
+    for (int offset = lo; offset <= hi; offset += step) {
+        while (j < slope_changes.size() && slope_changes[j].first <= offset) {
+            fvalue += current_slope * (slope_changes[j].first - sig_last);
+            sig_last = slope_changes[j].first;
             current_slope += slope_changes[j].second;
             j++;
         }
-        fvalue += current_slope;
-        score_curve.push_back(fvalue);
+        fvalue += current_slope * (offset - sig_last);
+        sig_last = offset;
+        curve.push_back(fvalue);
     }
 
-    return score_curve;
+    return curve;
 }
 
-std::vector<int> split_alignment(std::vector<std::pair<int,int>> read_srt, std::vector<std::pair<int,int>> reference_spans, float p) {
-    int score = 0;
-    std::vector<float> t_new;
+std::vector<int> split_alignment(const std::vector<std::pair<int,int>>& read_srt, const std::vector<std::pair<int,int>>& reference_spans, float p, int base_offset) {
+    // Every span is scored on the same grid of offsets around the one nosplit
+    // already found. Sharing the grid is what makes the indexes comparable
+    // from one span to the next each span having its own base was why the offsets came out wrong before
+    int lo = base_offset - SPLIT_WINDOW_MS;
+    int hi = base_offset + SPLIT_WINDOW_MS;
+
+    std::vector<double> t_prev = score_curve(read_srt[0], reference_spans, lo, hi, SPLIT_STEP_MS);
     std::vector<std::vector<int>> all_to;
-    std::vector<float> t_prev = score_curve(read_srt[0], reference_spans);
-    for (int n= 1; n < read_srt.size(); n++) {
-        std::vector<float> scores = score_curve(read_srt[n], reference_spans);
-        std::vector<float> s(scores.size(), 0);
-        float s_max = 0;
-        t_new.clear();
-        for (int sigma = 0; sigma < scores.size(); sigma++) {
-            int shift = sigma + read_srt[n].first - read_srt[n-1].second;
-            if (shift >= 0 && shift < t_prev.size()) {
-                s_max = std::max(s_max, t_prev[shift]);
+
+    for (int n = 1; n < (int)read_srt.size(); n++) {
+        std::vector<double> scores = score_curve(read_srt[n], reference_spans, lo, hi, SPLIT_STEP_MS);
+        std::vector<double> t_new(scores.size(), 0);
+        std::vector<int> to(scores.size(), 0);
+
+        // Subtitles are not allowed to swap places. If this span sits at sigma
+        // the one before it can sit anywhere up to sigma plus the gap between
+        // them, so we walk a running best over everything allowed so far
+        int gap = (read_srt[n].first - read_srt[n-1].second) / SPLIT_STEP_MS;
+        double s_max = -std::numeric_limits<double>::infinity();
+        int s_max_at = 0;
+        int reached = -1;
+
+        for (int sigma = 0; sigma < (int)scores.size(); sigma++) {
+            int allowed = std::min(sigma + gap, (int)t_prev.size() - 1);
+            while (reached < allowed) {
+                reached++;
+                if (t_prev[reached] > s_max) {
+                    s_max = t_prev[reached];
+                    s_max_at = reached;
+                }
             }
-            s[sigma] = s_max;
-        }
-        std::vector<int> to;
-        for (int i = 0; i < scores.size(); i++) {
-            if (t_prev[i] >= s[i] - p) {
-                t_new.push_back(scores[i] + t_prev[i]);
-                to.push_back(i); 
+
+            // Staying where the previous span sits is free, moving somewhere else costs the split penalty
+            if (t_prev[sigma] >= s_max - p) {
+                t_new[sigma] = scores[sigma] + t_prev[sigma];
+                to[sigma] = sigma;
             } else {
-                t_new.push_back(scores[i] + s[i] - p);
-                int shift = i + read_srt[n].first - read_srt[n-1].second;
-                to.push_back(shift);  
+                t_new[sigma] = scores[sigma] + s_max - p;
+                to[sigma] = s_max_at;
             }
         }
         all_to.push_back(to);
-        t_prev = t_new;
+        t_prev.swap(t_new);
     }
+
+    int sigma_best = 0;
+    for (int i = 1; i < (int)t_prev.size(); i++) {
+        if (t_prev[i] > t_prev[sigma_best]) {
+            sigma_best = i;
+        }
+    }
+
+     // Walk the choices back and turn the grid positions into real offsets
     std::vector<int> offsets(read_srt.size());
+    offsets[read_srt.size() - 1] = lo + sigma_best * SPLIT_STEP_MS;
 
-int sigma_best = 0;
-for (int i = 1; i < t_prev.size(); i++) {
-    if (t_prev[i] > t_prev[sigma_best]) {
-        sigma_best = i;
+    for (int n = all_to.size() - 1; n >= 0; n--) {
+        sigma_best = all_to[n][sigma_best];
+        offsets[n] = lo + sigma_best * SPLIT_STEP_MS;
     }
-}
-offsets[read_srt.size() - 1] = sigma_best;
-
-for (int n = all_to.size() - 1; n >= 0; n--) {
-    sigma_best = all_to[n][sigma_best];
-    offsets[n] = sigma_best;
-}
-return offsets;
+    return offsets;
 }
 
-/* 
+/*
 // Finds the offset between the movie and subtitles
 std::tuple<double, double, float> cross_correlation(std::vector<int> activity_profile, std::vector<float> RMS) {
     // starts checking one minute behind
@@ -387,8 +485,8 @@ std::tuple<double, double, float> cross_correlation(std::vector<int> activity_pr
 
             for (int offset = -10000; offset <= 10000; offset += 10) {
                 float sum = 0;
-                int offset_index = offset / 10; 
-                
+                int offset_index = offset / 10;
+
                 for (int i = chunks; i < chunks + 90000; ++i) {
                     int rms_index = i - offset_index;
                     if (rms_index >= 0 && rms_index < RMS.size()) {
@@ -411,7 +509,7 @@ std::tuple<double, double, float> cross_correlation(std::vector<int> activity_pr
         weights.push_back(sharpness);
         }
     }
-    
+
     auto [slope, intercept] = linear_regression(t_vals, delta_vals, weights);
     std::cout << "Slope: " << slope << '\n';
     std::cout << "Intercept: " << intercept << '\n';

--- a/engine/correlate.h
+++ b/engine/correlate.h
@@ -22,10 +22,32 @@
 #include <fftw3.h>
 #include <algorithm>
 
-std::pair<double, double> linear_regression(std::vector<double> x, std::vector<double> y, std::vector<double> w);
-std::pair<double, double> fft_crosscorrelate(std::vector<int> activity_profile, std::vector<int> srt_profile);
-int score_calculator(std::vector<std::pair<int, int>> read_srt, std::vector<std::pair<int, int>> reference_spans, int x);
-int best_offset(std::vector<std::pair<int, int>> read_srt, std::vector<std::pair<int, int>> reference_spans);
-std::vector<float> score_curve(std::vector<std::pair<int,int>> span, std::vector<std::pair<int,int>> reference_spans);
-std::vector<int> split_alignment(std::vector<std::pair<int,int>> read_srt, std::vector<std::pair<int,int>> reference_spans, float p);
+// Nothing is ever off by more than this - past it we are looking at the wrong
+// film rather than a sync problem, so there is no reason to search that far
+const int MAX_OFFSET_MS = 15 * 60 * 1000;
 
+// Split mode searches around the offset nosplit already found. 10ms steps over
+// two minutes each way is enough for ad breaks and extended cuts and keeps the
+// backtracking table down to something a container can hold
+const int SPLIT_WINDOW_MS = 120000;
+const int SPLIT_STEP_MS = 10;
+
+// The ratios you actually run into - a subtitle timed for one framerate played
+// back at another. Anything outside this list is a transcode gone wrong, and
+// that is what the regression is still there for
+const double FRAMERATE_RATIOS[] = {
+    1.0,
+    24.0/23.976, 23.976/24.0,
+    25.0/24.0,   24.0/25.0,
+    25.0/23.976, 23.976/25.0,
+    30.0/29.97,  29.97/30.0,
+    30.0/25.0,   25.0/30.0
+};
+
+std::pair<double, double> linear_regression(const std::vector<double>& x, const std::vector<double>& y, const std::vector<double>& w);
+std::pair<double, double> fft_crosscorrelate(const std::vector<int>& activity_profile, const std::vector<int>& srt_profile);
+double score_calculator(const std::vector<std::pair<int, int>>& read_srt, const std::vector<std::pair<int, int>>& reference_spans, int x);
+std::pair<int, double> best_offset(const std::vector<std::pair<int, int>>& read_srt, const std::vector<std::pair<int, int>>& reference_spans);
+std::tuple<double, int, double> best_framerate(const std::vector<std::pair<int, int>>& read_srt, const std::vector<std::pair<int, int>>& reference_spans);
+std::vector<double> score_curve(const std::pair<int,int>& span, const std::vector<std::pair<int,int>>& reference_spans, int lo, int hi, int step);
+std::vector<int> split_alignment(const std::vector<std::pair<int,int>>& read_srt, const std::vector<std::pair<int,int>>& reference_spans, float p, int base_offset);

--- a/engine/decoder.cpp
+++ b/engine/decoder.cpp
@@ -31,21 +31,24 @@ AVFormatContext* open_file(const char* filename) {
         std::cerr << "ERROR could not get stream info" << '\n';
         return nullptr;
     }
-    
+
     std::cout << "Format: " << pFormatContext->iformat->name << " Duration: " << pFormatContext->duration << '\n';
     return pFormatContext;
 }
 
-// Find the audio by looping though the streams from pFormatContext then checking by matching with the media type
+// Find the audio by looping though the streams from pFormatContext then checking by matching with the media type.
+// Take the one ffmpeg marked as default if there is one - the first audio track
+// is often a commentary or a dub and syncing to that gives the wrong answer
 int find_audio_stream(const AVFormatContext* pFormatContext) {
-    for(int i {0}; i < pFormatContext->nb_streams; ++i) {
+    int first = -1;
+    for(int i {0}; i < (int)pFormatContext->nb_streams; ++i) {
         if (pFormatContext->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_AUDIO) {
-            // std::cout << i << '\n';
-            return i;
+            if (first < 0) first = i;
+            if (pFormatContext->streams[i]->disposition & AV_DISPOSITION_DEFAULT) return i;
         }
 
-    }    
-    return -1;
+    }
+    return first;
 }
 
 // This is supposed to decode and open the audio from find_audio_stream()
@@ -66,9 +69,11 @@ AVCodecContext* open_audio_decoder(const AVFormatContext* pFormatContext, int au
     AVCodecContext *dec_ctx = avcodec_alloc_context3(decoder);
     if (!dec_ctx) {
         std::cerr << "Failed to allocate decoder context" << '\n';
+        return nullptr;
     }
     // This to get value from AVCodecParameters to the AVCodecContext so avcodec_open2 can work with it
     avcodec_parameters_to_context(dec_ctx, pFormatContext->streams[audio_stream_index]->codecpar);
+    dec_ctx->thread_count = 0;   // let ffmpeg use every core it wants
 
     int ret = avcodec_open2(dec_ctx, NULL, NULL);
     if (ret < 0) {
@@ -78,80 +83,137 @@ AVCodecContext* open_audio_decoder(const AVFormatContext* pFormatContext, int au
     return dec_ctx;
 }
 
-// Decode the audio! My idea with vector float is that every float is a PCM-sample and a vector will grow while it reads packages from the file 
-std::vector<float> decode_audio(AVFormatContext* pFormatContext, AVCodecContext* dec_ctx ,int audio_stream_index) {
+// Grabs one sample as a float no matter which of the usual formats we got back.
+// Planar keeps every channel in its own buffer, packed interleaves them
+static float sample_at(const AVFrame* frame, int channel, int index) {
+    int channels = frame->ch_layout.nb_channels;
+    switch (frame->format) {
+        case AV_SAMPLE_FMT_FLTP:
+            return ((const float*)frame->data[channel])[index];
+        case AV_SAMPLE_FMT_FLT:
+            return ((const float*)frame->data[0])[index * channels + channel];
+        case AV_SAMPLE_FMT_S16P:
+            return ((const int16_t*)frame->data[channel])[index] / 32768.0f;
+        case AV_SAMPLE_FMT_S16:
+            return ((const int16_t*)frame->data[0])[index * channels + channel] / 32768.0f;
+        default:
+            return 0.0f;
+    }
+}
+
+// Decode the audio and squash it down to 8kHz mono on the way out. libfvad only
+// wants 8kHz anyway and holding a whole film as floats first was eating well
+// over a gigabyte before we threw almost all of it away again
+std::vector<int16_t> decode_audio(AVFormatContext* pFormatContext, AVCodecContext* dec_ctx ,int audio_stream_index) {
     int ret;
     AVPacket *packet = av_packet_alloc();
     AVFrame *frame = av_frame_alloc();
 
-    std::vector<float> decoded = {};
+    std::vector<int16_t> decoded = {};
 
     if (!packet || !frame) {
         std::cerr << "Could not allocate frame or packet" << '\n';
         return {};
     }
 
-    if (dec_ctx->sample_fmt != AV_SAMPLE_FMT_FLTP) {
-        std::cerr << "Unsupported sample format: " 
+    if (dec_ctx->sample_fmt != AV_SAMPLE_FMT_FLTP && dec_ctx->sample_fmt != AV_SAMPLE_FMT_FLT &&
+        dec_ctx->sample_fmt != AV_SAMPLE_FMT_S16P && dec_ctx->sample_fmt != AV_SAMPLE_FMT_S16) {
+        std::cerr << "Unsupported sample format: "
                   << av_get_sample_fmt_name(dec_ctx->sample_fmt) << '\n';
         return {};
     }
 
-    // Read all the packets
-    while (1) {
-        // Reads the compressed package from  file and puts it in a packet. 
-        // Returns negative when the file is done
-        if ((ret = av_read_frame(pFormatContext, packet)) < 0) {
-            return decoded;
+    // Tell ffmpeg to throw away everything that isnt the audio track, otherwise
+    // it pulls the entire video through the demuxer just so we can skip it
+    for (int i = 0; i < (int)pFormatContext->nb_streams; ++i)
+        if (i != audio_stream_index)
+            pFormatContext->streams[i]->discard = AVDISCARD_ALL;
+
+    // 5.1 tracks keep the dialogue on the centre channel, so listen to that one
+    // on its own when it is there - mixing it with the music and the effects
+    // only buries the speech we are trying to find
+    int channels = dec_ctx->ch_layout.nb_channels;
+    int centre = av_channel_layout_index_from_channel(&dec_ctx->ch_layout, AV_CHAN_FRONT_CENTER);
+
+    // 44100 does not divide into 8000, so we walk the input with a fractional
+    // step and average everything that falls between two output samples. The
+    // averaging doubles as a crude low pass. The old code took every 5th sample
+    // which really gave 8820Hz and stretched the whole timeline by 9 percent
+    double step = dec_ctx->sample_rate / 8000.0;
+    double taken = 0;
+    double sum = 0;
+    int count = 0;
+
+    auto take_frames = [&]() {
+        while (true) {
+            // Retrieves one decoded frame "EAGAIN" basically means not ready yet send more packages.
+            ret = avcodec_receive_frame(dec_ctx, frame);
+            if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) break;
+            if (ret < 0) {
+                std::cerr << "Error while receiving a frame from the decoder" << '\n';
+                break;
+            }
+
+            for (int i = 0; i < frame->nb_samples; ++i) {
+                float s;
+                if (centre >= 0) {
+                    s = sample_at(frame, centre, i);
+                } else {
+                    s = 0;
+                    for (int c = 0; c < channels; ++c) s += sample_at(frame, c, i);
+                    s /= channels;
+                }
+
+                sum += s;
+                count++;
+                taken += 1.0;
+                if (taken >= step) {
+                    float avg = (float)(sum / count);
+                    if (avg > 1.0f) avg = 1.0f;
+                    if (avg < -1.0f) avg = -1.0f;
+                    decoded.push_back((int16_t)(avg * 32767.0f));
+                    sum = 0;
+                    count = 0;
+                    taken -= step;   // keep the leftover so the rate stays exact
+                }
+            }
+            av_frame_unref(frame);
         }
+    };
+
+    // Read all the packets
+    while (av_read_frame(pFormatContext, packet) >= 0) {
         // Filter so we only get audio streams
         if (packet->stream_index == audio_stream_index) {
             // Send the stuff to the decoder
             ret = avcodec_send_packet(dec_ctx, packet);
             if (ret < 0) {
                 std::cerr << "Error while sending a packet to the decoder" << '\n';
-                return decoded;
+                av_packet_unref(packet);
+                break;
             }
-            // This loop is so we can get the decoded frames. The loop is because i tested without and it didnt work so a packet can have multiple frames
-            while (ret >= 0) {
-                // Retrieves one decoded frame "EAGAIN" basically means not ready yet send more packages.
-                ret = avcodec_receive_frame(dec_ctx, frame);
-
-                if (ret == AVERROR(EAGAIN) || ret == AVERROR_EOF) {
-                    break;
-                } else if (ret < 0) {
-                    std::cerr << "Error while receiving a frame from the decoder" << '\n';
-                    return decoded;
-                }
-                // The line below basically is just telling it to treat these bytes as another type here its "the data in raw bytes in frame->data[0] is actually floats"
-                // Or i hope so at least it works ))
-                float* samples = reinterpret_cast<float*>(frame->data[0]);
-                for (int i = 0;i < frame->nb_samples ; ++i) {
-                    decoded.push_back(samples[i]);
-                }
-            }
+            take_frames();
         }
+        av_packet_unref(packet);   // without this every packet leaks its buffer
     }
-    return decoded; 
-}
 
-std::vector<int16_t> convert_to_8kHz(std::vector<float>& decoded, AVCodecContext* dec_ctx) {
-    int ratio = dec_ctx->sample_rate / 8000;
-    std::vector<int16_t> output;
-    output.reserve(decoded.size() / ratio);
-    
-    // Take every nth sample to go from original rate to 8kHz
-    for (size_t i = 0; i < decoded.size(); i += ratio) {
-        output.push_back((int16_t)(decoded[i] * 32767.0f));
-    }
-    return output;
+    // Flush whatever the decoder is still sitting on, otherwise the last second
+    // or so of the film never reaches us
+    avcodec_send_packet(dec_ctx, NULL);
+    take_frames();
+
+    av_frame_free(&frame);
+    av_packet_free(&packet);
+    return decoded;
 }
 
 std::vector<float> calculate_fvad(const std::vector<int16_t>& pcm, int sample_rate) {
     std::vector<float> result = {};
 
     Fvad *vad = fvad_new();
-    fvad_set_mode(vad, 0);
+    // Mode 0 called almost everything speech, music included. 2 is the middle
+    // ground - the short gaps it leaves get glued back together in reference_spans
+    fvad_set_mode(vad, 2);
     fvad_set_sample_rate(vad, sample_rate);
 
     int frame_size = sample_rate / 100; // 10ms
@@ -163,96 +225,6 @@ std::vector<float> calculate_fvad(const std::vector<int16_t>& pcm, int sample_ra
     fvad_free(vad);
     return result;
 }
-
-
-// This function below i just couldnt figure out how to make it work
-//Used the one above instead think its almost as good just not perfect sound wise but functional  
-// Pls help or i need to look at it later!!!
-/*
-// Takes decoded float samples and squishes them down to 8kHz int16
-// libfvad only needs 8k since speech sits under 4kHz anyway
-std::vector<int16_t> convert_to_8kHz(const std::vector<float>& decoded, AVCodecContext* dec_ctx) {
-    SwrContext* swr_ctx = nullptr;
-
-    // Build the mono layouts the safe way. The AV_CHANNEL_LAYOUT_MONO macro
-    // makes a struct that swr_convert later rejects, so we let ffmpeg fill it
-    AVChannelLayout mono_in;
-    AVChannelLayout mono_out;
-    av_channel_layout_from_mask(&mono_in, AV_CH_LAYOUT_MONO);
-    av_channel_layout_from_mask(&mono_out, AV_CH_LAYOUT_MONO);
-
-    // input is mono float at movie rate, output is mono int16 at 8kHz
-    int ret = swr_alloc_set_opts2(
-        &swr_ctx,
-        &mono_out,
-        AV_SAMPLE_FMT_S16,
-        8000,
-        &mono_in,
-        AV_SAMPLE_FMT_FLT,
-        dec_ctx->sample_rate,
-        0,
-        NULL
-    );
-    if (ret < 0 || !swr_ctx) {
-        std::cerr << "Could not set up resampler" << '\n';
-        return {};
-    }
-
-    if (swr_init(swr_ctx) < 0) {
-        std::cerr << "Could not init resampler" << '\n';
-        swr_free(&swr_ctx);
-        return {};
-    }
-
-    // Figure out how many samples we get out and grab the memory up front
-    // so we dont reallocate mid conversion
-    int64_t out_count = (int64_t)decoded.size() * 8000 / dec_ctx->sample_rate + 256;
-    std::vector<int16_t> output(out_count);
-
-    const uint8_t* in_ptr  = (const uint8_t*)decoded.data();
-    uint8_t*       out_ptr = (uint8_t*)output.data();
-
-    std::cout << "in samples: " << decoded.size() << " out_count: " << out_count << " in_rate: " << dec_ctx->sample_rate << '\n';
-
-    // do the actual resample in one go
-    int samples_out = swr_convert(swr_ctx, &out_ptr, (int)out_count, &in_ptr, (int)decoded.size());
-    if (samples_out < 0) {
-        char errbuf[128];
-        av_strerror(samples_out, errbuf, sizeof(errbuf));
-        std::cerr << "Error during resampling: " << errbuf << '\n';
-        swr_free(&swr_ctx);
-        return {};
-    }
-
-    // flush whatever the resampler still has buffered internally
-    out_ptr = (uint8_t*)(output.data() + samples_out);
-    int flushed = swr_convert(swr_ctx, &out_ptr, (int)(out_count - samples_out), NULL, 0);
-
-    av_channel_layout_uninit(&mono_in);
-    av_channel_layout_uninit(&mono_out);
-    swr_free(&swr_ctx);
-
-    output.resize(samples_out + flushed);
-    return output;
-}
-
-std::vector<float> calculate_fvad(const std::vector<int16_t>& pcm, int sample_rate) {
-    std::vector<float> result = {};
-
-    Fvad *vad = fvad_new();
-    fvad_set_mode(vad, 0);
-    fvad_set_sample_rate(vad, sample_rate);
-
-    int frame_size = sample_rate / 100; // 10ms
-    for (int i = 0; i + frame_size <= (int)pcm.size(); i += frame_size) {
-        int r = fvad_process(vad, pcm.data() + i, frame_size);
-        result.push_back(r == 1 ? 1.0f : 0.0f);
-    }
-
-    fvad_free(vad);
-    return result;
-}
-*/
 
 
 // use fvad instead i think
@@ -271,7 +243,7 @@ std::vector<float> calculate_FFT(const std::vector<float>& decoded, int sample_r
     int out_n = (window_size/2) + 1;
 
     fftw_complex *out;
-    out = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * out_n);  
+    out = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * out_n);
 
     for (int i = 0; i < N; ++i) {
         chunk.push_back(decoded[i]);
@@ -311,7 +283,7 @@ std::vector<float> calculate_RMS(const std::vector<float>& decoded, int sample_r
         float j = decoded[i];
         j *= j;
         sum += j;
-        
+
         if (i % window_size == window_size - 1) {
             sum /= window_size;
             sum = sqrt(sum);

--- a/engine/decoder.h
+++ b/engine/decoder.h
@@ -29,6 +29,5 @@ extern "C" {
 AVFormatContext* open_file(const char* filename);
 int find_audio_stream(const AVFormatContext* pFormatContext);
 AVCodecContext* open_audio_decoder(const AVFormatContext* pFormatContext, int audio_stream_index);
-std::vector<float> decode_audio(AVFormatContext* pFormatContext, AVCodecContext* dec_ctx, int audio_stream_index);
-std::vector<int16_t> convert_to_8kHz(std::vector<float>& decoded, AVCodecContext* dec_ctx);
+std::vector<int16_t> decode_audio(AVFormatContext* pFormatContext, AVCodecContext* dec_ctx, int audio_stream_index);
 std::vector<float> calculate_fvad(const std::vector<int16_t>& pcm, int sample_rate);

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -16,38 +16,78 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <cstring>
 #include <cmath>
 #include "decoder.h"
 #include "srt_parser.h"
 #include "correlate.h"
 #include "write_subtitle.h"
 
+// The formats the parsers and the writers both handle. Callers can ask for the
+// list with --formats so they know what is safe to hand us
+const char* subtitle_formats[] = {".srt", ".ass", ".ssa", ".vtt"};
+
 bool is_subtitle(const std::string& path) {
-    for (auto& ext : {".srt", ".ass", ".ssa", ".vtt"})
+    for (auto& ext : subtitle_formats)
         if (path.size() > strlen(ext) && path.substr(path.size() - strlen(ext)) == ext)
             return true;
     return false;
 }
 
-void write_offsets(const std::string& path, const std::vector<int>& offsets, const std::vector<int>& mapping) {
-    if (path.ends_with(".srt"))
-        write_srt_split(path.c_str(), path.c_str(), offsets, mapping);
-    else if (path.ends_with(".ass") || path.ends_with(".ssa"))
-        write_ass_split(path.c_str(), path.c_str(), offsets, mapping);
-    else if (path.ends_with(".vtt"))
-        write_vtt_split(path.c_str(), path.c_str(), offsets, mapping);
+// The format follows the file we read, the destination is wherever the caller asked us to put it
+void write_offsets(const std::string& in_path, const std::string& out_path, const std::vector<int>& offsets, const std::vector<int>& mapping) {
+    if (in_path.ends_with(".srt"))
+        write_srt_split(in_path.c_str(), out_path.c_str(), offsets, mapping);
+    else if (in_path.ends_with(".ass") || in_path.ends_with(".ssa"))
+        write_ass_split(in_path.c_str(), out_path.c_str(), offsets, mapping);
+    else if (in_path.ends_with(".vtt"))
+        write_vtt_split(in_path.c_str(), out_path.c_str(), offsets, mapping);
 }
 
-int main(int argc, const char *argv[]) {
-    if (argc < 3) {
-        std::cerr << "Usage: lapse <video_or_subtitle> <subtitle> [ols|nosplit|split] [penalty]\n";
+void usage() {
+    std::cerr << "Usage: lapse <video_or_subtitle> <subtitle> [ols|nosplit|split] [penalty] [--output <path>] [--no-backup]\n";
+    std::cerr << "       lapse --formats\n";
+}
+
+int run(int argc, const char *argv[]) {
+    // Pull the flags out first, whatever is left over is positional like before
+    std::vector<std::string> args;
+    std::string output_path;
+    bool make_backup = true;
+
+    for (int i = 1; i < argc; i++) {
+        std::string arg = argv[i];
+        if (arg == "--formats") {
+            for (auto& ext : subtitle_formats)
+                std::cout << ext << '\n';
+            return 0;
+        } else if (arg == "--output") {
+            if (i + 1 >= argc) { usage(); return -1; }
+            output_path = argv[++i];
+        } else if (arg == "--no-backup") {
+            make_backup = false;
+        } else {
+            args.push_back(arg);
+        }
+    }
+
+    if (args.size() < 2) {
+        usage();
         return -1;
     }
 
-    std::string ref_path   = argv[1];
-    std::string input_path = argv[2];
-    std::string mode       = (argc >= 4) ? argv[3] : "nosplit";
-    float p                = (argc >= 5) ? std::stof(argv[4]) : 6.0f;
+    std::string ref_path   = args[0];
+    std::string input_path = args[1];
+    std::string mode       = (args.size() >= 3) ? args[2] : "nosplit";
+    float p                = (args.size() >= 4) ? std::stof(args[3]) : 6.0f;
+
+    if (!is_subtitle(input_path)) {
+        std::cerr << "Unsupported subtitle format: " << input_path << '\n';
+        return 1;
+    }
+
+    // No --output means carry on overwriting the file we were given
+    if (output_path.empty()) output_path = input_path;
 
     std::vector<int> reference_activity;
     std::vector<std::pair<int,int>> ref_spans;
@@ -58,44 +98,77 @@ int main(int argc, const char *argv[]) {
         reference_activity = activity(ref_spans);
     } else {
         AVFormatContext* AVC = open_file(ref_path.c_str());
+        if (!AVC) return 1;
+
         int audio_stream_index = find_audio_stream(AVC);
         AVCodecContext* OAD = open_audio_decoder(AVC, audio_stream_index);
-        std::vector<float> decoded = decode_audio(AVC, OAD, audio_stream_index);
-        std::vector<int16_t> pcm = convert_to_8kHz(decoded, OAD);
-        decoded.clear(); decoded.shrink_to_fit();
+        if (!OAD) {
+            std::cerr << "No audio track we can decode in: " << ref_path << '\n';
+            return 1;
+        }
+
+        std::vector<int16_t> pcm = decode_audio(AVC, OAD, audio_stream_index);
+        if (pcm.empty()) {
+            std::cerr << "Got no audio out of: " << ref_path << '\n';
+            return 1;
+        }
+
         std::vector<float> fvad = calculate_fvad(pcm, 8000);
         pcm.clear(); pcm.shrink_to_fit();
         reference_activity = std::vector<int>(fvad.begin(), fvad.end());
         ref_spans = reference_spans(reference_activity);
     }
 
-    auto [spans, mapping] = process_spans(read_subtitle(input_path));
+    if (ref_spans.empty()) {
+        std::cerr << "No speech found in: " << ref_path << '\n';
+        return 1;
+    }
+
+    auto [spans, mapping] = process_spans(read_subtitle(input_path), mode != "split");
     if (spans.empty()) {
         std::cerr << "No timestamps found in: " << input_path << '\n';
         return 1;
     }
 
+    if (make_backup) backup_file(input_path.c_str());
+
     if (mode == "ols") {
-        std::vector<int> input_activity = activity(spans);
-        auto [slope, intercept] = fft_crosscorrelate(reference_activity, input_activity);
+        // Try the framerates people actually ship first. Only when none of them
+        // fit do we go back to measuring the drift chunk by chunk, which is the
+        // one thing that can still catch a stretch that isnt a standard ratio
+        auto [ratio, offset, confidence] = best_framerate(spans, ref_spans);
+        double slope = ratio - 1.0;
+        double intercept = offset / 1000.0;
+
+        if (confidence < 0.5) {
+            std::cout << "No framerate fit well, measuring the drift instead\n";
+            std::vector<int> input_activity = activity(spans);
+            auto [s, i] = fft_crosscorrelate(reference_activity, input_activity);
+            slope = s;
+            intercept = i;
+        }
+
         if (input_path.ends_with(".srt"))
-            write_srt_OLS(input_path.c_str(), input_path.c_str(), slope, intercept);
+            write_srt_OLS(input_path.c_str(), output_path.c_str(), slope, intercept);
         else if (input_path.ends_with(".ass") || input_path.ends_with(".ssa"))
-            write_ass_OLS(input_path.c_str(), input_path.c_str(), slope, intercept);
+            write_ass_OLS(input_path.c_str(), output_path.c_str(), slope, intercept);
         else if (input_path.ends_with(".vtt"))
-            write_vtt_OLS(input_path.c_str(), input_path.c_str(), slope, intercept);
-        std::cout << "Done (ols): slope=" << slope << " intercept=" << intercept << "s -> " << input_path << '\n';
+            write_vtt_OLS(input_path.c_str(), output_path.c_str(), slope, intercept);
+        std::cout << "Done (ols): slope=" << slope << " intercept=" << intercept << "s confidence=" << confidence << " -> " << output_path << '\n';
 
     } else if (mode == "nosplit") {
-        int offset = best_offset(spans, ref_spans);
+        auto [offset, confidence] = best_offset(spans, ref_spans);
         std::vector<int> offsets(spans.size(), offset);
-        write_offsets(input_path, offsets, mapping);
-        std::cout << "Done (nosplit): offset=" << offset << "ms -> " << input_path << '\n';
+        write_offsets(input_path, output_path, offsets, mapping);
+        std::cout << "Done (nosplit): offset=" << offset << "ms confidence=" << confidence << " -> " << output_path << '\n';
 
     } else if (mode == "split") {
-        std::vector<int> offsets = split_alignment(spans, ref_spans, p);
-        write_offsets(input_path, offsets, mapping);
-        std::cout << "Done (split, p=" << p << "): " << input_path << '\n';
+        // Lock onto the whole file first and let the split search work around
+        // that it only has to look at the offsets near the one we found
+        auto [offset, confidence] = best_offset(spans, ref_spans);
+        std::vector<int> offsets = split_alignment(spans, ref_spans, p, offset);
+        write_offsets(input_path, output_path, offsets, mapping);
+        std::cout << "Done (split, p=" << p << "): base=" << offset << "ms confidence=" << confidence << " -> " << output_path << '\n';
 
     } else {
         std::cerr << "Unknown mode: " << mode << ". Use ols, nosplit or split.\n";
@@ -103,4 +176,14 @@ int main(int argc, const char *argv[]) {
     }
 
     return 0;
+}
+
+// A bad file should come back as an error the caller can read, not as a crash
+int main(int argc, const char *argv[]) {
+    try {
+        return run(argc, argv);
+    } catch (const std::exception& e) {
+        std::cerr << e.what() << '\n';
+        return 1;
+    }
 }

--- a/engine/srt_parser.cpp
+++ b/engine/srt_parser.cpp
@@ -15,6 +15,68 @@
 
 #include "srt_parser.h"
 
+// A utf-8 BOM sits in front of the very first line and would otherwise trip up
+// whatever we try to read out of it
+static void strip_bom(std::string& line) {
+    if (line.size() >= 3 &&
+        (unsigned char)line[0] == 0xEF &&
+        (unsigned char)line[1] == 0xBB &&
+        (unsigned char)line[2] == 0xBF)
+        line.erase(0, 3);
+}
+
+std::string trim(const std::string& s) {
+    size_t a = s.find_first_not_of(" \t\r\n");
+    if (a == std::string::npos) return "";
+    size_t b = s.find_last_not_of(" \t\r\n");
+    return s.substr(a, b - a + 1);
+}
+
+// Reads a timestamp starting at "from" and returns it in ms, or -1 if there
+// isnt one. We just walk the digits instead of counting characters - files in
+// the wild write 0:00:01.00, 00:00:01,000 and 00:01.000 and all of them are
+// supposed to work
+int parse_timestamp(const std::string& line, size_t from) {
+    std::vector<int> parts;
+    int value = 0;
+    int digits = 0;
+    bool started = false;
+
+    size_t i = from;
+    while (i < line.size() && (line[i] == ' ' || line[i] == '\t')) i++;
+
+    for (; i < line.size(); i++) {
+        char c = line[i];
+        if (c >= '0' && c <= '9') {
+            value = value * 10 + (c - '0');
+            digits++;
+            started = true;
+        } else if (started && (c == ':' || c == ',' || c == '.')) {
+            parts.push_back(value);
+            value = 0;
+            digits = 0;
+        } else {
+            break;  // whitespace or vtt cue settings - the timestamp ended here
+        }
+    }
+    if (!started) return -1;
+    parts.push_back(value);
+
+    // Last group is the fraction. Three digits means milliseconds, two means
+    // the centiseconds that ass files use
+    int frac = parts.back();
+    parts.pop_back();
+    if (digits == 2) frac *= 10;
+    else if (digits == 1) frac *= 100;
+
+    if (parts.size() < 2 || parts.size() > 3) return -1;
+    int sec = parts.back(); parts.pop_back();
+    int min = parts.back(); parts.pop_back();
+    int hour = parts.empty() ? 0 : parts.back();
+
+    return hour * 3600000 + min * 60000 + sec * 1000 + frac;
+}
+
 std::vector<std::pair<int,int>> read_subtitle(const std::string& path) {
     if (path.ends_with(".srt"))
         return read_srt(path.c_str());
@@ -25,136 +87,149 @@ std::vector<std::pair<int,int>> read_subtitle(const std::string& path) {
     throw std::runtime_error("Unsupported subtitle format: " + path);
 }
 
+// Every line holding "-->" gets an entry even when we cannot read it - the
+// writers walk the same lines later and would drift out of step otherwise
 std::vector<std::pair<int, int>> read_srt(const char* filename) {
     std::vector<std::pair<int, int>> timestamps;
     std::string line {};
     std::ifstream read_file(filename);
+    bool first = true;
     while (getline (read_file, line)) {
-        if (line.find("-->") != std::string::npos) {
-            int start_ms {};
-            int end_ms {};
+        if (first) { strip_bom(line); first = false; }
 
-            int hours =std::stoi(line.substr(0, 2));
-            start_ms = hours * 3600000;
-            int min =std::stoi(line.substr(3, 2));
-            start_ms += min * 60000;
-            int sec =std::stoi(line.substr(6, 2));
-            start_ms += sec * 1000;
-            int mil_sec =std::stoi(line.substr(9, 3));
-            start_ms += mil_sec;
+        size_t arrow = line.find("-->");
+        if (arrow == std::string::npos) continue;
 
-            int e_hours =std::stoi(line.substr(17, 2));
-            end_ms = e_hours * 3600000;
-            int e_min =std::stoi(line.substr(20, 2));
-            end_ms += e_min * 60000;
-            int e_sec =std::stoi(line.substr(23, 2));
-            end_ms += e_sec * 1000;
-            int e_mil_sec =std::stoi(line.substr(26, 3));
-            end_ms += e_mil_sec;
+        int start_ms = parse_timestamp(line, 0);
+        int end_ms   = parse_timestamp(line, arrow + 3);
 
+        if (start_ms < 0 || end_ms < 0)
+            timestamps.push_back({0, 0});   // dropped later, keeps the count right
+        else
             timestamps.push_back(std::make_pair(start_ms, end_ms));
-        }
     }
     return timestamps;
+}
+
+// Positions of the commas on a Dialogue or Format line
+std::vector<size_t> ass_commas(const std::string& line) {
+    std::vector<size_t> commas;
+    for (size_t i = 0; i < line.size(); i++)
+        if (line[i] == ',') commas.push_back(i);
+    return commas;
+}
+
+// Field 0 is the one right after the colon. Only works for fields that have a
+// comma after them, which is fine since we never touch the text field
+bool ass_field(const std::string& line, const std::vector<size_t>& commas, int index, size_t& from, size_t& len) {
+    if (index < 0 || index >= (int)commas.size()) return false;
+    size_t colon = line.find(':');
+    if (colon == std::string::npos) return false;
+
+    from = (index == 0) ? colon + 1 : commas[index - 1] + 1;
+    if (from > commas[index]) return false;
+    len = commas[index] - from;
+    return true;
+}
+
+// The Format line says which columns hold the times. Almost every file puts
+// them at 1 and 2 but the spec lets them sit anywhere
+std::pair<int,int> ass_time_columns(const std::string& format_line) {
+    std::vector<size_t> commas = ass_commas(format_line);
+    int start_col = -1;
+    int end_col = -1;
+
+    for (int i = 0; i < (int)commas.size(); i++) {
+        size_t from, len;
+        if (!ass_field(format_line, commas, i, from, len)) continue;
+        std::string name = trim(format_line.substr(from, len));
+        if (name == "Start") start_col = i;
+        if (name == "End")   end_col = i;
+    }
+    return {start_col, end_col};
 }
 
 std::vector<std::pair<int, int>> read_ass(const char* filename) {
     std::vector<std::pair<int, int>> timestamps;
     std::string line {};
     std::ifstream read_file(filename);
+    int start_col = 1;
+    int end_col = 2;
+    bool first = true;
+
     while (getline(read_file, line)) {
-        if (line.find("Dialogue:") != 0) continue;
+        if (first) { strip_bom(line); first = false; }
 
-        // Format: Dialogue: Layer,Start,End,...
-        int first_comma = line.find(',');
-        int second_comma = line.find(',', first_comma + 1);
-        int third_comma = line.find(',', second_comma + 1);
+        if (line.rfind("Format:", 0) == 0) {
+            auto [s, e] = ass_time_columns(line);
+            if (s >= 0 && e >= 0) { start_col = s; end_col = e; }
+            continue;
+        }
+        if (line.rfind("Dialogue:", 0) != 0) continue;
 
-        std::string start_str = line.substr(first_comma + 1, second_comma - first_comma - 1);
-        std::string end_str = line.substr(second_comma + 1, third_comma - second_comma - 1);
+        std::vector<size_t> commas = ass_commas(line);
+        size_t from, len;
+        int start_ms = -1;
+        int end_ms = -1;
 
-        auto parse_ass_time = [](const std::string& t) {
-            int h = std::stoi(t.substr(0, 1));
-            int m = std::stoi(t.substr(2, 2));
-            int s = std::stoi(t.substr(5, 2));
-            int cs = std::stoi(t.substr(8, 2));
-            return h * 3600000 + m * 60000 + s * 1000 + cs * 10;
-        };
+        if (ass_field(line, commas, start_col, from, len))
+            start_ms = parse_timestamp(line.substr(from, len), 0);
+        if (ass_field(line, commas, end_col, from, len))
+            end_ms = parse_timestamp(line.substr(from, len), 0);
 
-        timestamps.push_back({parse_ass_time(start_str), parse_ass_time(end_str)});
+        if (start_ms < 0 || end_ms < 0)
+            timestamps.push_back({0, 0});
+        else
+            timestamps.push_back({start_ms, end_ms});
     }
     return timestamps;
 }
 
+// vtt cues look just like srt ones once we stop counting characters
 std::vector<std::pair<int,int>> read_vtt(const char* filename) {
-    std::vector<std::pair<int,int>> timestamps;
-    std::string line;
-    std::ifstream f(filename);
-    while (std::getline(f, line)) {
-        if (line.find("-->") == std::string::npos) continue;
-        try {
-            int h1  = std::stoi(line.substr(0, 2));
-            int m1  = std::stoi(line.substr(3, 2));
-            int s1  = std::stoi(line.substr(6, 2));
-            int ms1 = std::stoi(line.substr(9, 3));
-            int start = h1*3600000 + m1*60000 + s1*1000 + ms1;
-
-            int h2  = std::stoi(line.substr(17, 2));
-            int m2  = std::stoi(line.substr(20, 2));
-            int s2  = std::stoi(line.substr(23, 2));
-            int ms2 = std::stoi(line.substr(26, 3));
-            int end = h2*3600000 + m2*60000 + s2*1000 + ms2;
-
-            timestamps.push_back({start, end});
-        } catch (...) {}
-    }
-    return timestamps;
+    return read_srt(filename);
 }
 
 
-std::pair<std::vector<std::pair<int,int>>, std::vector<int>> process_spans(std::vector<std::pair<int, int>> timestamps) {
-    std::vector<int> mapping;
+// Cues that sit on top of each other normally get glued into one span - they
+// are the same moment on screen and counting them twice only skews the score.
+// Split mode asks for them separately though: when a file jumps halfway through
+// the two halves overlap each other once sorted, and merging across that jump
+// welds cues from either side of it together so they can never come apart again
+std::pair<std::vector<std::pair<int,int>>, std::vector<int>> process_spans(const std::vector<std::pair<int, int>>& timestamps, bool merge) {
+    // Sort the cues by time but remember where each one sat in the file the
+    // writers go through the file top to bottom and look their span back up
     std::vector<std::pair<std::pair<int,int>, int>> ys;
-    for (int i = 0; i < timestamps.size(); i++) {
-        ys.push_back({timestamps[i], i});
+    for (int i = 0; i < (int)timestamps.size(); i++) {
+        int start = timestamps[i].first;
+        int end   = timestamps[i].second;
+        if (end < start) std::swap(start, end);
+        if (end == start) continue;    // empty or unreadable cue, nothing to line up
+        ys.push_back({{start, end}, i});
     }
 
     std::sort(ys.begin(), ys.end());
 
-
-    for (int i = 0; i < ys.size(); i++) {
-        int place = 0;
-        if (ys[i].first.first - ys[i].first.second == 0) {
-            ys.erase(ys.begin() + i--);
-            //ys[i].second = -1;
-        }
-
-        if (ys[i].first.second < ys[i].first.first) {
-            place = ys[i].first.first;
-            ys[i].first.first = ys[i].first.second;
-            ys[i].first.second = place;
-        }
-    }
     std::vector<std::pair<int,int>> spans;
-    std::vector<int> original_placement;
-    int new_end;
-    int n = 0;
+    std::vector<int> mapping(timestamps.size(), 0);
+    std::vector<bool> kept(timestamps.size(), false);
 
-    for (int i = 0; i < ys.size(); i++) {
-        original_placement.push_back(n);
-
-
-        if (spans.empty() || ys[i].first.first >= spans.back().second) {
-            spans.push_back({ys[i].first.first, ys[i].first.second});
-            n += 1;
+    for (int i = 0; i < (int)ys.size(); i++) {
+        if (!merge || spans.empty() || ys[i].first.first >= spans.back().second) {
+            spans.push_back(ys[i].first);
         } else {
-            new_end = std::max(ys[i].first.second, spans.back().second);
-            spans.back().second = new_end;
+            spans.back().second = std::max(ys[i].first.second, spans.back().second);
         }
+        mapping[ys[i].second] = (int)spans.size() - 1;
+        kept[ys[i].second] = true;
     }
 
-    for (int i = 0; i < ys.size(); i++) {
-        mapping.push_back(original_placement[ys[i].second]);
+    // The cues we threw out still take up a line in the file point them at
+    // the span before them so the writer keeps shifting them along with it
+    int last = 0;
+    for (int i = 0; i < (int)mapping.size(); i++) {
+        if (kept[i]) last = mapping[i];
+        else mapping[i] = last;
     }
 
     return {spans, mapping};
@@ -162,16 +237,16 @@ std::pair<std::vector<std::pair<int,int>>, std::vector<int>> process_spans(std::
 
 
 
-// Build some sort of activity profile that checks every 10ms for dialogue 
-std::vector<int> activity(std::vector<std::pair<int, int>> spans) {
+// Build some sort of activity profile that checks every 10ms for dialogue
+std::vector<int> activity(const std::vector<std::pair<int, int>>& spans) {
     if (spans.empty()) return {};
     std::vector<int> activity_profile = {};
     int j = 0;
     for (int i = 0; i <= spans.back().second; i += 10) {
-        while (j < spans.size() && i > spans[j].second) {
+        while (j < (int)spans.size() && i > spans[j].second) {
             j++;
         }
-        if (i >= spans[j].first && i <= spans[j].second) {
+        if (j < (int)spans.size() && i >= spans[j].first && i <= spans[j].second) {
             activity_profile.push_back(1);
         } else {
             activity_profile.push_back(0);
@@ -180,22 +255,37 @@ std::vector<int> activity(std::vector<std::pair<int, int>> spans) {
     return activity_profile;
 }
 
-std::vector<std::pair<int, int>> reference_spans(std::vector<int> activity_profile) {
-    std::vector<std::pair<int, int>> reference_spans;
+// Turns the vad output back into spans. One entry is one 10ms frame so the index has to be scaled before anything compares this to subtitle timestamps
+std::vector<std::pair<int, int>> reference_spans(const std::vector<int>& activity_profile) {
+    std::vector<std::pair<int, int>> raw;
     bool check = false;
     int start_ms = 0;
     int end_ms = 0;
-    for (int i = 0; i < activity_profile.size(); i++) {
+    for (int i = 0; i < (int)activity_profile.size(); i++) {
         if (activity_profile[i] == 1 && !check) {
             check = true;
-            start_ms = i;
+            start_ms = i * 10;
         }
-        if ((activity_profile[i] == 0 && check) || (i == activity_profile.size() - 1 && check)) {
+        if ((activity_profile[i] == 0 && check) || (i == (int)activity_profile.size() - 1 && check)) {
             check = false;
-            end_ms = i;
-            reference_spans.push_back({start_ms, end_ms});
+            end_ms = i * 10;
+            raw.push_back({start_ms, end_ms});
         }
     }
-    return reference_spans;
-}
 
+    // The vad flickers on and off inside a sentence, so glue spans that are only a breath apart together
+    //and drop whatever is left too short to be speech single frames of noise otherwise fill the reference with junk
+    std::vector<std::pair<int, int>> spans;
+    for (auto& s : raw) {
+        if (!spans.empty() && s.first - spans.back().second < 200)
+            spans.back().second = s.second;
+        else
+            spans.push_back(s);
+    }
+
+    std::vector<std::pair<int, int>> out;
+    for (auto& s : spans)
+        if (s.second - s.first >= 100) out.push_back(s);
+
+    return out;
+}

--- a/engine/srt_parser.h
+++ b/engine/srt_parser.h
@@ -21,10 +21,17 @@
 #include <vector>
 #include <algorithm>
 
+int parse_timestamp(const std::string& line, size_t from);
+std::string trim(const std::string& s);
+
+std::vector<size_t> ass_commas(const std::string& line);
+bool ass_field(const std::string& line, const std::vector<size_t>& commas, int index, size_t& from, size_t& len);
+std::pair<int,int> ass_time_columns(const std::string& format_line);
+
 std::vector<std::pair<int,int>> read_subtitle(const std::string& path);
 std::vector<std::pair<int, int>> read_srt(const char* filename);
 std::vector<std::pair<int, int>> read_ass(const char* filename);
 std::vector<std::pair<int,int>> read_vtt(const char* filename);
-std::pair<std::vector<std::pair<int,int>>, std::vector<int>> process_spans(std::vector<std::pair<int, int>> timestamps);
-std::vector<int> activity(std::vector<std::pair<int, int>> spans);
-std::vector<std::pair<int, int>> reference_spans(std::vector<int> activity_profile);
+std::pair<std::vector<std::pair<int,int>>, std::vector<int>> process_spans(const std::vector<std::pair<int, int>>& timestamps, bool merge = true);
+std::vector<int> activity(const std::vector<std::pair<int, int>>& spans);
+std::vector<std::pair<int, int>> reference_spans(const std::vector<int>& activity_profile);

--- a/engine/write_subtitle.cpp
+++ b/engine/write_subtitle.cpp
@@ -14,350 +14,213 @@
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
 #include "write_subtitle.h"
+#include "srt_parser.h"
 
-// writes the original file as .bak
+// Writes the original file as .bak, but never on top of one we already made -
+// running lapse twice used to replace the untouched original with the shifted
+// version and then there was no way back
 void backup_file(const char* path) {
-    std::filesystem::copy_file(path, std::string(path) + ".bak", std::filesystem::copy_options::overwrite_existing);
+    std::string backup = std::string(path) + ".bak";
+    if (std::filesystem::exists(backup)) return;
+    std::filesystem::copy_file(path, backup, std::filesystem::copy_options::overwrite_existing);
 }
 
+// How a timestamp gets moved. Either one line for the whole file, or a lookup
+// per cue for nosplit and split
+struct Shift {
+    bool ols = false;
+    double slope = 0;
+    double intercept_s = 0;
+    std::vector<int> offsets;
+    std::vector<int> mapping;
+
+    int apply(int ms, int cue) const {
+        if (ols) return (int)(ms * (1.0 + slope) + intercept_s * 1000.0);
+        if (cue < 0 || cue >= (int)mapping.size()) return ms;
+        int span = mapping[cue];
+        if (span < 0 || span >= (int)offsets.size()) return ms;
+        return ms + offsets[span];
+    }
+};
+
+// Reads the file in one go and drops a utf-8 BOM if it is there
+static std::string load_file(const char* path) {
+    std::ifstream in(path, std::ios::binary);
+    if (!in) throw std::runtime_error("Cannot open subtitle: " + std::string(path));
+
+    std::string raw((std::istreambuf_iterator<char>(in)), {});
+
+    if (raw.size() >= 2 && (unsigned char)raw[0] == 0xFF && (unsigned char)raw[1] == 0xFE)
+        throw std::runtime_error("File looks like utf-16, convert it to utf-8 first: " + std::string(path));
+    if (raw.size() >= 2 && (unsigned char)raw[0] == 0xFE && (unsigned char)raw[1] == 0xFF)
+        throw std::runtime_error("File looks like utf-16, convert it to utf-8 first: " + std::string(path));
+
+    if (raw.size() >= 3 &&
+        (unsigned char)raw[0] == 0xEF &&
+        (unsigned char)raw[1] == 0xBB &&
+        (unsigned char)raw[2] == 0xBF)
+        return raw.substr(3);
+
+    return raw;
+}
+
+static std::string ms_to_ts(int ms, char ms_sep) {
+    if (ms < 0) ms = 0;
+    int h  = ms / 3600000; ms %= 3600000;
+    int m  = ms / 60000;   ms %= 60000;
+    int sc = ms / 1000;    ms %= 1000;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%02d:%02d:%02d%c%03d", h, m, sc, ms_sep, ms);
+    return buf;
+}
+
+static std::string ms_to_ass_ts(int ms) {
+    if (ms < 0) ms = 0;
+    int h  = ms / 3600000; ms %= 3600000;
+    int m  = ms / 60000;   ms %= 60000;
+    int sc = ms / 1000;    ms %= 1000;
+    int cs = ms / 10;
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%01d:%02d:%02d.%02d", h, m, sc, cs);
+    return buf;
+}
+
+// srt and vtt are the same file with a different character in front of the
+// milliseconds, so they go through here together. We write to a temp file and
+// move it into place at the end if something throws halfway the subtitle the user already had is still whole
+static void write_cues(const char* input_path, const char* output_path, char ms_sep, const Shift& shift) {
+    std::istringstream ss(load_file(input_path));
+
+    std::string temp_path = std::string(output_path) + ".tmp";
+    std::ofstream out(temp_path, std::ios::binary);
+    if (!out) throw std::runtime_error("Cannot write subtitle: " + std::string(output_path));
+
+    std::string line;
+    int cue = 0;
+    while (std::getline(ss, line)) {
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+
+        size_t arrow = line.find("-->");
+        if (arrow != std::string::npos) {
+            int start_ms = parse_timestamp(line, 0);
+            int end_ms   = parse_timestamp(line, arrow + 3);
+
+            if (start_ms >= 0 && end_ms >= 0) {
+                // vtt hangs cue settings on the end of the line, keep them
+                std::string tail;
+                size_t after = line.find_first_not_of(" \t", arrow + 3);
+                if (after != std::string::npos) {
+                    size_t space = line.find_first_of(" \t", after);
+                    if (space != std::string::npos) tail = line.substr(space);
+                }
+                line = ms_to_ts(shift.apply(start_ms, cue), ms_sep) + " --> " +
+                       ms_to_ts(shift.apply(end_ms, cue), ms_sep) + tail;
+            }
+            cue++;       // counted even when it did not parse, the reader did the same
+        }
+
+        out << line << "\n";
+    }
+
+    out.close();
+    std::filesystem::rename(temp_path, output_path);
+}
+
+static void write_dialogue(const char* input_path, const char* output_path, const Shift& shift) {
+    std::istringstream ss(load_file(input_path));
+
+    std::string temp_path = std::string(output_path) + ".tmp";
+    std::ofstream out(temp_path, std::ios::binary);
+    if (!out) throw std::runtime_error("Cannot write subtitle: " + std::string(output_path));
+
+    std::string line;
+    int cue = 0;
+    int start_col = 1;
+    int end_col = 2;
+
+    while (std::getline(ss, line)) {
+        if (!line.empty() && line.back() == '\r')
+            line.pop_back();
+
+        if (line.rfind("Format:", 0) == 0) {
+            auto [s, e] = ass_time_columns(line);
+            if (s >= 0 && e >= 0) { start_col = s; end_col = e; }
+
+        } else if (line.rfind("Dialogue:", 0) == 0) {
+            std::vector<size_t> commas = ass_commas(line);
+            size_t sf, sl, ef, el;
+
+            if (ass_field(line, commas, start_col, sf, sl) && ass_field(line, commas, end_col, ef, el)) {
+                int start_ms = parse_timestamp(line.substr(sf, sl), 0);
+                int end_ms   = parse_timestamp(line.substr(ef, el), 0);
+
+                if (start_ms >= 0 && end_ms >= 0) {
+                    std::string new_start = ms_to_ass_ts(shift.apply(start_ms, cue));
+                    std::string new_end   = ms_to_ass_ts(shift.apply(end_ms, cue));
+
+                    // Put the later field back first so the earlier one keeps
+                    // the position we just looked up
+                    if (sf < ef) {
+                        line.replace(ef, el, new_end);
+                        line.replace(sf, sl, new_start);
+                    } else {
+                        line.replace(sf, sl, new_start);
+                        line.replace(ef, el, new_end);
+                    }
+                }
+            }
+            cue++;
+        }
+
+        out << line << "\n";
+    }
+
+    out.close();
+    std::filesystem::rename(temp_path, output_path);
+}
 
 void write_srt_OLS(const char* input_path, const char* output_path, double slope, double intercept_s) {
-    
-    backup_file(input_path);
-
-    std::ifstream in(input_path, std::ios::binary);
-    if (!in) throw std::runtime_error("Cannot open SRT: " + std::string(input_path));
-
-    std::string raw((std::istreambuf_iterator<char>(in)), {});
-    in.close();
-
-    // strip UTF-8 BOM if present
-    size_t bom_start = 0;
-    if (raw.size() >= 3 &&
-        (unsigned char)raw[0] == 0xEF &&
-        (unsigned char)raw[1] == 0xBB &&
-        (unsigned char)raw[2] == 0xBF)
-        bom_start = 3;
-
-    std::istringstream ss(raw.substr(bom_start));
-    std::ofstream out(output_path, std::ios::binary);
-    if (!out) throw std::runtime_error("Cannot write SRT: " + std::string(output_path));
-
-    auto ts_to_ms = [](const std::string& s, int offset) -> int {
-        int h  = std::stoi(s.substr(offset, 2));
-        int m  = std::stoi(s.substr(offset + 3, 2));
-        int sc = std::stoi(s.substr(offset + 6, 2));
-        int ms = std::stoi(s.substr(offset + 9, 3));
-        return h * 3600000 + m * 60000 + sc * 1000 + ms;
-    };
-
-    auto ms_to_ts = [](int ms) -> std::string {
-        if (ms < 0) ms = 0;
-        int h  = ms / 3600000; ms %= 3600000;
-        int m  = ms / 60000;   ms %= 60000;
-        int sc = ms / 1000;    ms %= 1000;
-        char buf[13];
-        snprintf(buf, sizeof(buf), "%02d:%02d:%02d,%03d", h, m, sc, ms);
-        return buf;
-    };
-
-    std::string line;
-    while (std::getline(ss, line)) {
-        if (!line.empty() && line.back() == '\r')
-            line.pop_back();
-
-            if (line.find("-->") != std::string::npos && line.size() >= 29) {
-                try {
-                    int start_ms  = ts_to_ms(line, 0);
-                    int end_ms    = ts_to_ms(line, 17);
-                    int new_start = (int)(start_ms * (1.0 + slope) + intercept_s * 1000.0);
-                    int new_end   = (int)(end_ms   * (1.0 + slope) + intercept_s * 1000.0);
-                    line = ms_to_ts(new_start) + " --> " + ms_to_ts(new_end);
-                } catch (...) {}
-            }
-
-        out << line << "\n";
-    }
-}
-
-void write_ass_OLS(const char* input_path, const char* output_path, double slope, double intercept_s) {
-    
-    backup_file(input_path);
-
-    std::ifstream in(input_path, std::ios::binary);
-    if (!in) throw std::runtime_error("Cannot open ASS or SSA: " + std::string(input_path));
-
-    std::string raw((std::istreambuf_iterator<char>(in)), {});
-    in.close();
-
-    // strip UTF-8 BOM if present
-    size_t bom_start = 0;
-    if (raw.size() >= 3 &&
-        (unsigned char)raw[0] == 0xEF &&
-        (unsigned char)raw[1] == 0xBB &&
-        (unsigned char)raw[2] == 0xBF)
-        bom_start = 3;
-
-    std::istringstream ss(raw.substr(bom_start));
-    std::ofstream out(output_path, std::ios::binary);
-    if (!out) throw std::runtime_error("Cannot write ASS or SSA: " + std::string(output_path));
-
-    auto ts_to_ms = [](const std::string& s) -> int {
-        int h  = std::stoi(s.substr(0, 1));
-        int m  = std::stoi(s.substr(2, 2));
-        int sc = std::stoi(s.substr(5, 2));
-        int cs = std::stoi(s.substr(8, 2));
-        return h * 3600000 + m * 60000 + sc * 1000 + cs * 10;
-    };
-
-    auto ms_to_ts = [](int ms) -> std::string {
-        if (ms < 0) ms = 0;
-        int h  = ms / 3600000; ms %= 3600000;
-        int m  = ms / 60000;   ms %= 60000;
-        int sc = ms / 1000;    ms %= 1000;
-        int cs = ms / 10;     ms %= 10;
-        char buf[13];
-        snprintf(buf, sizeof(buf), "%01d:%02d:%02d.%02d", h, m, sc, cs);
-        return buf;
-    };
-
-    std::string line;
-    while (std::getline(ss, line)) {
-        if (!line.empty() && line.back() == '\r')
-            line.pop_back();
-
-            if (line.find("Dialogue:") != std::string::npos) {
-                size_t c1 = line.find(',');
-                size_t c2 = line.find(',', c1 + 1);
-                size_t c3 = line.find(',', c2 + 1);
-
-                std::string start_str = line.substr(c1 + 1, c2 - c1 - 1);
-                std::string end_str   = line.substr(c2 + 1, c3 - c2 - 1);
-                std::string rest      = line.substr(c3);
-
-                try {
-                    int start_ms  = ts_to_ms(start_str);
-                    int end_ms    = ts_to_ms(end_str);
-                    int new_start = (int)(start_ms * (1.0 + slope) + intercept_s * 1000.0);
-                    int new_end   = (int)(end_ms   * (1.0 + slope) + intercept_s * 1000.0);
-                    line = line.substr(0, c1 + 1) + ms_to_ts(new_start) + "," + ms_to_ts(new_end) + rest;
-                } catch (...) {}
-            }
-
-        out << line << "\n";
-    }
+    Shift shift;
+    shift.ols = true;
+    shift.slope = slope;
+    shift.intercept_s = intercept_s;
+    write_cues(input_path, output_path, ',', shift);
 }
 
 void write_vtt_OLS(const char* input_path, const char* output_path, double slope, double intercept_s) {
-    backup_file(input_path);
-
-    std::ifstream in(input_path);
-    std::ofstream out(output_path);
-
-    auto ms_to_ts = [](int ms) -> std::string {
-        if (ms < 0) ms = 0;
-        int h  = ms / 3600000; ms %= 3600000;
-        int m  = ms / 60000;   ms %= 60000;
-        int s  = ms / 1000;    ms %= 1000;
-        char buf[13];
-        snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%03d", h, m, s, ms);
-        return buf;
-    };
-
-    std::string line;
-    while (std::getline(in, line)) {
-        if (!line.empty() && line.back() == '\r') line.pop_back();
-        if (line.find("-->") != std::string::npos && line.size() >= 29) {
-            try {
-                int h1  = std::stoi(line.substr(0, 2));
-                int m1  = std::stoi(line.substr(3, 2));
-                int s1  = std::stoi(line.substr(6, 2));
-                int ms1 = std::stoi(line.substr(9, 3));
-                int start = h1*3600000 + m1*60000 + s1*1000 + ms1;
-
-                int h2  = std::stoi(line.substr(17, 2));
-                int m2  = std::stoi(line.substr(20, 2));
-                int s2  = std::stoi(line.substr(23, 2));
-                int ms2 = std::stoi(line.substr(26, 3));
-                int end = h2*3600000 + m2*60000 + s2*1000 + ms2;
-
-                int new_start = (int)(start * (1.0 + slope) + intercept_s * 1000.0);
-                int new_end   = (int)(end   * (1.0 + slope) + intercept_s * 1000.0);
-                line = ms_to_ts(new_start) + " --> " + ms_to_ts(new_end);
-            } catch (...) {}
-        }
-        out << line << "\n";
-    }
+    Shift shift;
+    shift.ols = true;
+    shift.slope = slope;
+    shift.intercept_s = intercept_s;
+    write_cues(input_path, output_path, '.', shift);
 }
 
-void write_srt_split(const char* input_path, const char* output_path, std::vector<int> offsets, std::vector<int> mapping) {
-    backup_file(input_path);
-
-    std::ifstream in(input_path, std::ios::binary);
-    if (!in) throw std::runtime_error("Cannot open SRT: " + std::string(input_path));
-
-    std::string raw((std::istreambuf_iterator<char>(in)), {});
-    in.close();
-
-    size_t bom_start = 0;
-    if (raw.size() >= 3 &&
-        (unsigned char)raw[0] == 0xEF &&
-        (unsigned char)raw[1] == 0xBB &&
-        (unsigned char)raw[2] == 0xBF)
-        bom_start = 3;
-
-    std::istringstream ss(raw.substr(bom_start));
-    std::ofstream out(output_path, std::ios::binary);
-    if (!out) throw std::runtime_error("Cannot write SRT: " + std::string(output_path));
-
-    auto ts_to_ms = [](const std::string& s, int offset) -> int {
-        int h  = std::stoi(s.substr(offset, 2));
-        int m  = std::stoi(s.substr(offset + 3, 2));
-        int sc = std::stoi(s.substr(offset + 6, 2));
-        int ms = std::stoi(s.substr(offset + 9, 3));
-        return h * 3600000 + m * 60000 + sc * 1000 + ms;
-    };
-
-    auto ms_to_ts = [](int ms) -> std::string {
-        if (ms < 0) ms = 0;
-        int h  = ms / 3600000; ms %= 3600000;
-        int m  = ms / 60000;   ms %= 60000;
-        int sc = ms / 1000;    ms %= 1000;
-        char buf[13];
-        snprintf(buf, sizeof(buf), "%02d:%02d:%02d,%03d", h, m, sc, ms);
-        return buf;
-    };
-
-    std::string line;
-    int line_index = 0;
-    while (std::getline(ss, line)) {
-        if (!line.empty() && line.back() == '\r')
-            line.pop_back();
-
-        if (line.find("-->") != std::string::npos && line.size() >= 29) {
-            try {
-                int span_index = mapping[line_index];
-                int offset_ms = offsets[span_index];
-                int start_ms  = ts_to_ms(line, 0) + offset_ms;
-                int end_ms    = ts_to_ms(line, 17) + offset_ms;
-                line = ms_to_ts(start_ms) + " --> " + ms_to_ts(end_ms);
-                line_index++;
-            } catch (...) {}
-        }
-
-        out << line << "\n";
-    }
-}
-void write_ass_split(const char* input_path, const char* output_path, std::vector<int> offsets, std::vector<int> mapping) {
-    backup_file(input_path);
-
-    std::ifstream in(input_path, std::ios::binary);
-    if (!in) throw std::runtime_error("Cannot open ASS or SSA: " + std::string(input_path));
-
-    std::string raw((std::istreambuf_iterator<char>(in)), {});
-    in.close();
-
-    size_t bom_start = 0;
-    if (raw.size() >= 3 &&
-        (unsigned char)raw[0] == 0xEF &&
-        (unsigned char)raw[1] == 0xBB &&
-        (unsigned char)raw[2] == 0xBF)
-        bom_start = 3;
-
-    std::istringstream ss(raw.substr(bom_start));
-    std::ofstream out(output_path, std::ios::binary);
-    if (!out) throw std::runtime_error("Cannot write ASS or SSA: " + std::string(output_path));
-
-    auto ts_to_ms = [](const std::string& s) -> int {
-        int h  = std::stoi(s.substr(0, 1));
-        int m  = std::stoi(s.substr(2, 2));
-        int sc = std::stoi(s.substr(5, 2));
-        int cs = std::stoi(s.substr(8, 2));
-        return h * 3600000 + m * 60000 + sc * 1000 + cs * 10;
-    };
-
-    auto ms_to_ts = [](int ms) -> std::string {
-        if (ms < 0) ms = 0;
-        int h  = ms / 3600000; ms %= 3600000;
-        int m  = ms / 60000;   ms %= 60000;
-        int sc = ms / 1000;    ms %= 1000;
-        int cs = ms / 10;
-        char buf[13];
-        snprintf(buf, sizeof(buf), "%01d:%02d:%02d.%02d", h, m, sc, cs);
-        return buf;
-    };
-
-    std::string line;
-    int line_index = 0;
-    while (std::getline(ss, line)) {
-        if (!line.empty() && line.back() == '\r')
-            line.pop_back();
-
-        if (line.find("Dialogue:") != std::string::npos) {
-            try {
-                size_t c1 = line.find(',');
-                size_t c2 = line.find(',', c1 + 1);
-                size_t c3 = line.find(',', c2 + 1);
-
-                std::string start_str = line.substr(c1 + 1, c2 - c1 - 1);
-                std::string end_str   = line.substr(c2 + 1, c3 - c2 - 1);
-                std::string rest      = line.substr(c3);
-
-                int span_index = mapping[line_index];
-                int offset_ms  = offsets[span_index];
-                int start_ms   = ts_to_ms(start_str) + offset_ms;
-                int end_ms     = ts_to_ms(end_str) + offset_ms;
-                line = line.substr(0, c1 + 1) + ms_to_ts(start_ms) + "," + ms_to_ts(end_ms) + rest;
-                line_index++;
-            } catch (...) {}
-        }
-
-        out << line << "\n";
-    }
+void write_ass_OLS(const char* input_path, const char* output_path, double slope, double intercept_s) {
+    Shift shift;
+    shift.ols = true;
+    shift.slope = slope;
+    shift.intercept_s = intercept_s;
+    write_dialogue(input_path, output_path, shift);
 }
 
-void write_vtt_split(const char* input_path, const char* output_path, std::vector<int> offsets, std::vector<int> mapping) {
-    backup_file(input_path);
+void write_srt_split(const char* input_path, const char* output_path, const std::vector<int>& offsets, const std::vector<int>& mapping) {
+    Shift shift;
+    shift.offsets = offsets;
+    shift.mapping = mapping;
+    write_cues(input_path, output_path, ',', shift);
+}
 
-    std::ifstream in(input_path);
-    std::ofstream out(output_path);
+void write_vtt_split(const char* input_path, const char* output_path, const std::vector<int>& offsets, const std::vector<int>& mapping) {
+    Shift shift;
+    shift.offsets = offsets;
+    shift.mapping = mapping;
+    write_cues(input_path, output_path, '.', shift);
+}
 
-    auto ms_to_ts = [](int ms) -> std::string {
-        if (ms < 0) ms = 0;
-        int h  = ms / 3600000; ms %= 3600000;
-        int m  = ms / 60000;   ms %= 60000;
-        int s  = ms / 1000;    ms %= 1000;
-        char buf[13];
-        snprintf(buf, sizeof(buf), "%02d:%02d:%02d.%03d", h, m, s, ms);
-        return buf;
-    };
-
-    std::string line;
-    int line_index = 0;
-    while (std::getline(in, line)) {
-        if (!line.empty() && line.back() == '\r') line.pop_back();
-
-        if (line.find("-->") != std::string::npos && line.size() >= 29) {
-            try {
-                int h1  = std::stoi(line.substr(0, 2));
-                int m1  = std::stoi(line.substr(3, 2));
-                int s1  = std::stoi(line.substr(6, 2));
-                int ms1 = std::stoi(line.substr(9, 3));
-                int start = h1*3600000 + m1*60000 + s1*1000 + ms1;
-
-                int h2  = std::stoi(line.substr(17, 2));
-                int m2  = std::stoi(line.substr(20, 2));
-                int s2  = std::stoi(line.substr(23, 2));
-                int ms2 = std::stoi(line.substr(26, 3));
-                int end = h2*3600000 + m2*60000 + s2*1000 + ms2;
-
-                int span_index = mapping[line_index];
-                int offset_ms  = offsets[span_index];
-                line = ms_to_ts(start + offset_ms) + " --> " + ms_to_ts(end + offset_ms);
-                line_index++;
-            } catch (...) {}
-        }
-
-        out << line << "\n";
-    }
+void write_ass_split(const char* input_path, const char* output_path, const std::vector<int>& offsets, const std::vector<int>& mapping) {
+    Shift shift;
+    shift.offsets = offsets;
+    shift.mapping = mapping;
+    write_dialogue(input_path, output_path, shift);
 }

--- a/engine/write_subtitle.h
+++ b/engine/write_subtitle.h
@@ -20,12 +20,13 @@
 #include <sstream>
 #include <vector>
 #include <algorithm>
+#include <stdexcept>
 #include <filesystem>
 
 void backup_file(const char* path);
 void write_srt_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
 void write_ass_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
 void write_vtt_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
-void write_srt_split(const char* input_path, const char* output_path, std::vector<int> offsets, std::vector<int> mapping);
-void write_ass_split(const char* input_path, const char* output_path, std::vector<int> offsets, std::vector<int> mapping);
-void write_vtt_split(const char* input_path, const char* output_path, std::vector<int> offsets, std::vector<int> mapping);
+void write_srt_split(const char* input_path, const char* output_path, const std::vector<int>& offsets, const std::vector<int>& mapping);
+void write_ass_split(const char* input_path, const char* output_path, const std::vector<int>& offsets, const std::vector<int>& mapping);
+void write_vtt_split(const char* input_path, const char* output_path, const std::vector<int>& offsets, const std::vector<int>& mapping);


### PR DESCRIPTION
The watcher referenced a _last_processed dict that was never defined, so the first file event after startup raised NameError and nothing was picked up again until the container was restarted.

Python side:
- log output was buffered and never showed up in docker logs
- only .srt and three video extensions were looked at, and matching needed three words in common so movie.mkv and movie.srt never paired
- match subtitles to video instead of the other way round, so a video can have several subtitle files, look in the folder above for Subs folders, ignore language and tag words, and keep episode numbers apart
- wait for files to stop changing before touching them
- keep the offset and confidence the engine reports in the database, redo a pair when its subtitle is replaced, and stop retrying after a few failures
- handle SIGTERM so docker stop does not sit there for ten seconds
- skip @eaDir, #recycle and the other folders NAS boxes leave around
- drop the second backup, the engine already writes one
- MEDIA_ROOT takes more than one path, and mode, penalty, scan interval and confidence floor come from the environment

Engine:
- an unreadable subtitle format threw out of main and aborted, it now comes back as an error the caller can read
- lapse --formats prints the formats the binary handles, which is what the watcher asks on startup

Docker:
- PUID and PGID so corrected subtitles are not left owned by root
- PYTHONUNBUFFERED so the logs work

CI runs on pull requests against main. It builds the release binaries for both architectures and the image for both platforms, then syncs subtitles that are out by a known amount and checks they come back corrected.