### PR TITLE
Update repo references for GitHub username transfer to r-stisen

### DIFF
--- a/.github/scripts/accuracy.sh
+++ b/.github/scripts/accuracy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/build-ffmpeg.sh
+++ b/.github/scripts/build-ffmpeg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/build-fftw.sh
+++ b/.github/scripts/build-fftw.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/build-libfvad.sh
+++ b/.github/scripts/build-libfvad.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/check-db.py
+++ b/.github/scripts/check-db.py
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/compare-srt.py
+++ b/.github/scripts/compare-srt.py
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/fetch-onnxruntime.sh
+++ b/.github/scripts/fetch-onnxruntime.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/make-fixtures.py
+++ b/.github/scripts/make-fixtures.py
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/make-media.sh
+++ b/.github/scripts/make-media.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/package.sh
+++ b/.github/scripts/package.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/smoke-docker.sh
+++ b/.github/scripts/smoke-docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/smoke-engine.sh
+++ b/.github/scripts/smoke-engine.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/scripts/smoke-fallback.sh
+++ b/.github/scripts/smoke-fallback.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -43,4 +43,4 @@ jobs:
           file: docker/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/rs-jensen/lapse:latest
+          tags: ghcr.io/r-stisen/lapse:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Automatically fixes subtitle sync in your media library. Detects how far off your subtitles are and corrects them, including linear drift caused by framerate mismatches between the video and the subtitle file.
 
-A Jellyfin plugin is available at [rs-jensen/lapse-jellyfin-plugin](https://github.com/rs-jensen/lapse-jellyfin-plugin) for direct integration with your media server.
+A Jellyfin plugin is available at [r-stisen/lapse-jellyfin-plugin](https://github.com/r-stisen/lapse-jellyfin-plugin) for direct integration with your media server.
 
 The `lapse` binary is a C++ engine built on FFmpeg, libfvad and FFTW3, and it syncs one file at a time. The Docker image wraps that engine with a Python watcher that scans your library, matches subtitles to video and keeps a SQLite record so nothing gets processed twice. Run the binary by hand for a single file, or run the container to keep a whole library synced on its own.
 
@@ -89,7 +89,7 @@ The Docker image includes the C++ binary and the Python file watcher. Point it a
 ```yaml
 services:
   lapse:
-    image: ghcr.io/rs-jensen/lapse:latest
+    image: ghcr.io/r-stisen/lapse:latest
     restart: always
     volumes:
       - ./data:/data

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -16,7 +16,7 @@
 services:
   lapse:
     container_name: lapse
-    image: ghcr.io/rs-jensen/lapse:latest
+    image: ghcr.io/r-stisen/lapse:latest
     restart: always
     ulimits:
       core: 0

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/docker/main.py
+++ b/docker/main.py
@@ -1,5 +1,5 @@
 # LAPSE - Language-Agnostic subtitle synchronization engine
-# Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+# Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or

--- a/engine/align.cpp
+++ b/engine/align.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/align.h
+++ b/engine/align.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/charset.cpp
+++ b/engine/charset.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/charset.h
+++ b/engine/charset.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/correlate.cpp
+++ b/engine/correlate.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/correlate.h
+++ b/engine/correlate.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/cuetext.cpp
+++ b/engine/cuetext.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/cuetext.h
+++ b/engine/cuetext.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/decoder.cpp
+++ b/engine/decoder.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/decoder.h
+++ b/engine/decoder.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/log.cpp
+++ b/engine/log.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/log.h
+++ b/engine/log.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/silero.cpp
+++ b/engine/silero.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/silero.h
+++ b/engine/silero.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/srt_parser.cpp
+++ b/engine/srt_parser.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/srt_parser.h
+++ b/engine/srt_parser.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/write_subtitle.cpp
+++ b/engine/write_subtitle.cpp
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or

--- a/engine/write_subtitle.h
+++ b/engine/write_subtitle.h
@@ -1,5 +1,5 @@
 // LAPSE - Language-Agnostic subtitle synchronization engine
-// Copyright (C) 2026 Rasmus Stisen Jensen (rs-jensen)
+// Copyright (C) 2026 Rasmus Stisen Jensen (r-stisen)
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or


### PR DESCRIPTION
Updates ghcr.io image paths, jellyfin-plugin link, and copyright headers from rs-jensen to r-stisen, and points origin at the new GitHub URL.