### PR TITLE
Add --version flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,7 @@ add_executable(lapse
 
 target_compile_features(lapse PRIVATE cxx_std_20)
 target_include_directories(lapse PRIVATE engine)
+target_compile_definitions(lapse PRIVATE LAPSE_VERSION="${PROJECT_VERSION}")
 target_link_libraries(lapse PRIVATE lapse_ffmpeg lapse_fftw3 lapse_fvad)
 
 find_package(Threads REQUIRED)

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ By default LAPSE overwrites the subtitle file it was given and leaves a `.bak` n
 
 `--undo <subtitle>` puts the `.bak` back and removes it.
 
-Two flags answer a question and exit instead of syncing anything. `--formats` lists the subtitle extensions the engine reads and writes, and `--vad` prints `silero` or `libfvad` depending on which detector this copy can reach, exiting non-zero on the fallback.
+Three flags answer a question and exit instead of syncing anything. `--version` prints the version number, `--formats` lists the subtitle extensions the engine reads and writes, and `--vad` prints `silero` or `libfvad` depending on which detector this copy can reach, exiting non-zero on the fallback.
 
 Together they cover the four ways a caller may want the output handled:
 

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -306,6 +306,7 @@ static void report(const Report& r) {
 void usage() {
     std::cerr << "Usage: lapse <video_or_subtitle> <subtitle> [auto|ols|nosplit|split] [penalty] [--output <path>] [--no-backup] [--no-sidecar] [--no-embedded] [--full-scan] [--no-cache] [--force] [--json] [--quiet] [--dry-run] [--strict] [--confidence N] [--audio-track N] [--sub-track N]\n";
     std::cerr << "       --confidence N   how far the answer has to stand out before the original is overwritten (default " << sure_sigma << ")\n";
+    std::cerr << "       lapse --version\n";
     std::cerr << "       lapse --formats\n";
     std::cerr << "       lapse --vad\n";
     std::cerr << "       lapse --undo <subtitle>\n";
@@ -354,6 +355,9 @@ int run(int argc, const char *argv[]) {
         } else if (arg == "--undo") {
             if (i + 1 >= argc) { usage(); return -1; }
             return restore_backup(argv[++i]) ? 0 : 1;
+        } else if (arg == "--version") {
+            std::cout << LAPSE_VERSION << '\n';
+            return 0;
         } else if (arg == "--formats") {
             for (auto& ext : subtitle_formats)
                 std::cout << ext << '\n';


### PR DESCRIPTION
Prints the version number and exits. Someone integrating lapse into another tool asked for it so they do not have to hardcode the version.