### PR TITLE
Fix ghcr.io image owner after the repo move

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -43,4 +43,4 @@ jobs:
           file: docker/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/r-stisen/lapse:latest
+          tags: ghcr.io/schwponaco-org/lapse:latest

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The Docker image includes the C++ binary and the Python file watcher. Point it a
 ```yaml
 services:
   lapse:
-    image: ghcr.io/r-stisen/lapse:latest
+    image: ghcr.io/schwponaco-org/lapse:latest
     restart: always
     volumes:
       - ./data:/data

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@
 services:
   lapse:
     container_name: lapse
-    image: ghcr.io/r-stisen/lapse:latest
+    image: ghcr.io/schwponaco-org/lapse:latest
     restart: always
     ulimits:
       core: 0


### PR DESCRIPTION
The workflow still pushed to ghcr.io/r-stisen, which is why the build started failing with a permission error. Points at the org now.