### PR TITLE
Report why onnxruntime failed to load on Windows

### DIFF
--- a/engine/silero.cpp
+++ b/engine/silero.cpp
@@ -77,7 +77,9 @@ static library_handle load_from(const std::filesystem::path& path) {
     std::filesystem::path full = std::filesystem::absolute(path, ec);
     if (ec) full = path;
 #ifdef _WIN32
-    return LoadLibraryExW(full.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+    library_handle handle = LoadLibraryExW(full.c_str(), nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
+    if (!handle) say() << "Silero VAD: LoadLibrary(" << full.string() << ") failed, error " << GetLastError() << '\n';
+    return handle;
 #else
     return dlopen(full.string().c_str(), RTLD_LAZY | RTLD_LOCAL);
 #endif


### PR DESCRIPTION
Diagnostic-only change. The Windows release build has been failing to pick up onnxruntime.dll even though it ships right next to the binary, and there was no way to see why. This prints the actual Windows error code when LoadLibrary fails, so the next CI run tells us the real cause.