### PR TITLE
Fix corrupted onnxruntime.dll on Windows

### DIFF
--- a/.github/scripts/fetch-onnxruntime.sh
+++ b/.github/scripts/fetch-onnxruntime.sh
@@ -36,7 +36,11 @@ DIR="onnxruntime-${TARGET}-${VERSION}"
 case "$TARGET" in
     win-*)
         curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 20 -o ort.zip "${BASE}/${DIR}.zip"
-        unzip -q ort.zip "${DIR}/lib/onnxruntime.dll"
+        # MSYS2's unzip has been seen mangling this binary, likely a text mode line
+        # ending conversion, so extract it with Windows' own tool instead
+        pwsh=powershell.exe
+        command -v "$pwsh" > /dev/null 2>&1 || pwsh="/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+        "$pwsh" -NoProfile -Command "Expand-Archive -LiteralPath '$(cygpath -w "$PWD/ort.zip")' -DestinationPath '$(cygpath -w "$PWD")' -Force"
         cp "${DIR}/lib/onnxruntime.dll" "$DEST/onnxruntime.dll"
         ;;
     osx-*)


### PR DESCRIPTION
The diagnostic added in #49 showed LoadLibrary failing with error 193 (bad exe format). Comparing the extracted onnxruntime.dll against the zip's own directory listing, the extracted file was 40531 bytes larger than it should be, consistent with a text mode line ending conversion corrupting the binary during extraction. That points at MSYS2's unzip. This switches the Windows extraction step to PowerShell's Expand-Archive instead, which does not have that risk. macOS and Linux still use tar and are untouched.