### PR TITLE
Add MicroDVD support and pull embedded subtitles

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,12 @@ Sync subtitles to a video file (no-split, default):
 ./lapse video.mkv subtitles.srt
 ```
 
+Take the subtitles out of the video, sync them, and leave them next to it as `video.lapse.srt`:
+
+```bash
+./lapse video.mkv
+```
+
 Sync subtitles to another subtitle file (faster, more accurate):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -268,9 +268,9 @@ lapse/
 
 **Video:** All formats supported by FFmpeg (`.mp4`, `.mkv`, `.avi`, `.mov`, `.ts`, `.webm` and more)
 
-**Subtitles:** `.srt`, `.ass`, `.ssa`, `.vtt`
+**Subtitles:** `.srt`, `.ass`, `.ssa`, `.vtt`, `.sub` (MicroDVD)
 
-Planned to support: `.sup`, `.idx/.sub`, `.sub`, `.smi`, `.ttml`/`.dfxp`, `.sbv`, embedded MKV/MP4 tracks via mkvmerge/ffmpeg.
+Planned to support: `.sup`, `.idx/.sub`, `.smi`, `.ttml`/`.dfxp`, `.sbv`, embedded MKV/MP4 tracks via mkvmerge/ffmpeg.
 
 Run `lapse --formats` to print the subtitle formats your binary can read, one per line
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -5,6 +5,12 @@ one test with a subtitle file that belongs to a different film entirely.
 
 ## Read this before the tables
 
+***Note: LAPSE has since received significant changes that improve both
+accuracy and speed, so its current results are likely better than the numbers
+below. ffsubsync is still under active development, so its numbers may have
+shifted too. alass sees little to no maintenance these days, so its numbers
+here should still be a reasonably accurate picture.***
+
 **The films were picked to be hard.** They are not a random sample. They were
 chosen out of an ordinary home library for the traits that give a subtitle
 sync tool trouble: long running times, long stretches with no dialogue, heavy

--- a/engine/cuetext.cpp
+++ b/engine/cuetext.cpp
@@ -166,8 +166,28 @@ static std::vector<std::string> ass_cue_text(const std::string& path) {
     return out;
 }
 
+// the text is everything behind the two frame numbers, with | for a line break
+static std::vector<std::string> sub_cue_text(const std::string& path) {
+    std::vector<std::string> out;
+    std::istringstream file(load_text(path));
+    std::string line;
+
+    while (getline(file, line)) {
+        long long a, b;
+        size_t text_from;
+        if (!sub_frames(line, a, b, text_from)) continue;
+
+        std::string body = line.substr(text_from);
+        for (size_t i = 0; i < body.size(); i++)
+            if (body[i] == '|') body[i] = '\n';
+        out.push_back(body);
+    }
+    return out;
+}
+
 std::vector<std::string> read_cue_text(const std::string& path) {
     if (path.ends_with(".ass") || path.ends_with(".ssa")) return ass_cue_text(path);
+    if (path.ends_with(".sub")) return sub_cue_text(path);
     return srt_cue_text(path);
 }
 

--- a/engine/decoder.cpp
+++ b/engine/decoder.cpp
@@ -52,6 +52,65 @@ AVFormatContext* open_file(const char* filename) {
     return pFormatContext;
 }
 
+// Plenty of files carry no frame rate worth having, or claim something silly
+// like 1000 because they were muxed as variable rate. Time the packets instead
+// and take the middle gap, which is the rate whatever plays this will land on
+static double measure_fps(AVFormatContext* fmt, int stream) {
+    std::vector<int64_t> stamps;
+    AVPacket* packet = av_packet_alloc();
+    if (!packet) return 0;
+
+    while ((int)stamps.size() < 240 && av_read_frame(fmt, packet) >= 0) {
+        if (packet->stream_index == stream && packet->pts != AV_NOPTS_VALUE)
+            stamps.push_back(packet->pts);
+        av_packet_unref(packet);
+    }
+    av_packet_free(&packet);
+    if (stamps.size() < 30) return 0;
+
+    // packets arrive in the order they decode, not the order they are shown
+    std::sort(stamps.begin(), stamps.end());
+    std::vector<int64_t> gaps;
+    for (int i = 1; i < (int)stamps.size(); i++) gaps.push_back(stamps[i] - stamps[i - 1]);
+    std::sort(gaps.begin(), gaps.end());
+
+    int64_t middle = gaps[gaps.size() / 2];
+    if (middle <= 0) return 0;
+    double fps = 1.0 / (middle * av_q2d(fmt->streams[stream]->time_base));
+
+    // mkv counts in whole milliseconds, so 29.97 comes back as 30.303. Land on
+    // a rate somebody actually shot at when we are already nearly on one
+    static const double rates[] = {23.976, 24, 25, 29.97, 30, 50, 60};
+    for (double rate : rates)
+        if (std::fabs(fps - rate) < rate * 0.02) return rate;
+    return fps;
+}
+
+// MicroDVD subtitles count frames instead of time, so the video has to tell us
+// how long a frame lasts. Zero when the file has no video in it
+double probe_fps(const char* filename) {
+    AVFormatContext* fmt = nullptr;
+    if (avformat_open_input(&fmt, filename, nullptr, nullptr) != 0) return 0;
+
+    double fps = 0;
+    if (avformat_find_stream_info(fmt, nullptr) >= 0) {
+        int video = -1;
+        for (int i = 0; i < (int)fmt->nb_streams; i++) {
+            if (fmt->streams[i]->codecpar->codec_type == AVMEDIA_TYPE_VIDEO) { video = i; break; }
+        }
+
+        if (video >= 0) {
+            AVRational rate = fmt->streams[video]->avg_frame_rate;
+            if (rate.num <= 0 || rate.den <= 0) rate = fmt->streams[video]->r_frame_rate;
+            if (rate.num > 0 && rate.den > 0) fps = av_q2d(rate);
+            if (fps < 10 || fps > 120) fps = measure_fps(fmt, video);
+        }
+    }
+
+    avformat_close_input(&fmt);
+    return fps;
+}
+
 int find_audio_stream(const AVFormatContext* pFormatContext, int wanted) {
     int first = -1;
     int seen = 0;

--- a/engine/decoder.cpp
+++ b/engine/decoder.cpp
@@ -244,6 +244,102 @@ std::vector<std::pair<int, int>> embedded_spans(AVFormatContext* fmt, int wanted
     return {};
 }
 
+static std::string stamp(int ms) {
+    if (ms < 0) ms = 0;
+    char b[32];
+    snprintf(b, sizeof(b), "%02d:%02d:%02d,%03d", ms / 3600000, ms / 60000 % 60, ms / 1000 % 60, ms % 1000);
+    return b;
+}
+
+static std::string packet_text(AVPacket* p, AVCodecID id) {
+    std::string s((const char*)p->data, p->size);
+
+    if (id == AV_CODEC_ID_MOV_TEXT) {
+        if (s.size() < 2) return "";
+        int len = ((unsigned char)s[0] << 8) | (unsigned char)s[1];
+        if (len > (int)s.size() - 2) len = (int)s.size() - 2;
+        s = s.substr(2, len);
+    }
+
+    if (id == AV_CODEC_ID_ASS || id == AV_CODEC_ID_SSA) {
+        size_t at = 0;
+        int commas = 0;
+        while (at < s.size() && commas < 8) {
+            if (s[at] == ',') commas++;
+            at++;
+        }
+        if (commas < 8) return "";
+        s = s.substr(at);
+    }
+
+    std::string out;
+    for (size_t i = 0; i < s.size(); i++) {
+        if (s[i] == '\\' && i + 1 < s.size() && (s[i+1] == 'N' || s[i+1] == 'n')) { out += '\n'; i++; }
+        else if (s[i] == '|' && id == AV_CODEC_ID_MICRODVD) out += '\n';
+        else if (s[i] != '\r') out += s[i];
+    }
+    return out;
+}
+
+std::string embedded_text(const char* filename, int wanted) {
+    AVFormatContext* fmt = nullptr;
+    if (avformat_open_input(&fmt, filename, nullptr, nullptr) != 0) return "";
+    if (avformat_find_stream_info(fmt, nullptr) < 0) { avformat_close_input(&fmt); return ""; }
+
+    int index = -1;
+    int seen = 0;
+    for (int i = 0; i < (int)fmt->nb_streams; i++) {
+        AVStream* s = fmt->streams[i];
+        if (s->codecpar->codec_type != AVMEDIA_TYPE_SUBTITLE) continue;
+        if (!text_subtitle(s->codecpar->codec_id)) continue;
+        if (wanted >= 0) {
+            if (seen++ == wanted) { index = i; break; }
+            continue;
+        }
+        if (s->disposition & AV_DISPOSITION_FORCED) continue;
+        if (index < 0) index = i;
+        if (s->disposition & AV_DISPOSITION_DEFAULT) { index = i; break; }
+    }
+    if (index < 0) { avformat_close_input(&fmt); return ""; }
+
+    AVCodecID id = fmt->streams[index]->codecpar->codec_id;
+    AVRational tb = fmt->streams[index]->time_base;
+    AVRational millis = {1, 1000};
+    int offset = container_start_ms(fmt);
+
+    keep_only(fmt, index);
+    rewind_file(fmt);
+
+    std::vector<std::pair<std::pair<int,int>, std::string>> cues;
+    AVPacket* packet = av_packet_alloc();
+    if (!packet) { avformat_close_input(&fmt); return ""; }
+
+    while (av_read_frame(fmt, packet) >= 0) {
+        if (packet->stream_index == index && packet->pts != AV_NOPTS_VALUE && packet->duration > 0) {
+            int start = (int)av_rescale_q(packet->pts, tb, millis) - offset;
+            int length = (int)av_rescale_q(packet->duration, tb, millis);
+            std::string text = packet_text(packet, id);
+            if (start >= 0 && length > 0 && !text.empty())
+                cues.push_back({{start, start + length}, text});
+        }
+        av_packet_unref(packet);
+    }
+    av_packet_free(&packet);
+    avformat_close_input(&fmt);
+
+    if (cues.empty()) return "";
+    std::sort(cues.begin(), cues.end());
+    say() << "Taking subtitle track " << index << " out of the file, " << cues.size() << " cues\n";
+
+    std::string out;
+    for (int i = 0; i < (int)cues.size(); i++) {
+        out += std::to_string(i + 1) + "\n";
+        out += stamp(cues[i].first.first) + " --> " + stamp(cues[i].first.second) + "\n";
+        out += cues[i].second + "\n\n";
+    }
+    return out;
+}
+
 static void suppress_music(std::vector<float>& probability, const std::vector<float>& level) {
     int n = (int)level.size();
     if (n < 200) return;

--- a/engine/decoder.h
+++ b/engine/decoder.h
@@ -28,6 +28,7 @@ extern "C" {
 }
 
 AVFormatContext* open_file(const char* filename);
+double probe_fps(const char* filename);
 int find_audio_stream(const AVFormatContext* pFormatContext, int wanted = -1);
 AVCodecContext* open_audio_decoder(const AVFormatContext* pFormatContext, int audio_stream_index);
 std::vector<std::pair<int, int>> embedded_spans(AVFormatContext* pFormatContext, int wanted = -1);

--- a/engine/decoder.h
+++ b/engine/decoder.h
@@ -29,6 +29,7 @@ extern "C" {
 
 AVFormatContext* open_file(const char* filename);
 double probe_fps(const char* filename);
+std::string embedded_text(const char* filename, int wanted = -1);
 int find_audio_stream(const AVFormatContext* pFormatContext, int wanted = -1);
 AVCodecContext* open_audio_decoder(const AVFormatContext* pFormatContext, int audio_stream_index);
 std::vector<std::pair<int, int>> embedded_spans(AVFormatContext* pFormatContext, int wanted = -1);

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -35,13 +35,38 @@
 
 // The formats the parsers and the writers both handle. Callers can ask for the
 // list with --formats so they know what is safe to hand us
-const char* subtitle_formats[] = {".srt", ".ass", ".ssa", ".vtt"};
+const char* subtitle_formats[] = {".srt", ".ass", ".ssa", ".vtt", ".sub"};
 
 bool is_subtitle(const std::string& path) {
     for (auto& ext : subtitle_formats)
         if (path.size() > strlen(ext) && path.substr(path.size() - strlen(ext)) == ext)
             return true;
     return false;
+}
+
+// Nobody said what rate the frames count in and there is no video to ask. Both
+// files cover the same film though, so how long each of them runs for gives it
+// away, near enough to tell the handful of rates anyone ever used apart
+static double fps_from_length(const std::string& sub_path, const std::string& other_path) {
+    static const double rates[] = {23.976, 24, 25, 29.97, 30};
+
+    set_sub_fps(25);        // provisional, it is a ratio so this cancels out
+    auto [ours, _o] = process_spans(read_subtitle(sub_path));
+    auto [theirs, _t] = process_spans(read_subtitle(other_path));
+    set_sub_fps(0);
+    if (ours.empty() || theirs.empty()) return 0;
+
+    double we_run = ours.back().second - ours.front().first;
+    double they_run = theirs.back().second - theirs.front().first;
+    if (we_run <= 0 || they_run <= 0) return 0;
+
+    double got = 25.0 * we_run / they_run;
+    double best = 0;
+    for (double rate : rates)
+        if (best == 0 || std::fabs(rate - got) < std::fabs(best - got)) best = rate;
+
+    if (std::fabs(best - got) > best * 0.08) return 0;
+    return best;
 }
 
 // The format follows the file we read, the destination is wherever the caller asked us to put it
@@ -52,6 +77,8 @@ void write_offsets(const std::string& in_path, const std::string& out_path, doub
         write_ass_split(in_path.c_str(), out_path.c_str(), slope, offsets, mapping);
     else if (in_path.ends_with(".vtt"))
         write_vtt_split(in_path.c_str(), out_path.c_str(), slope, offsets, mapping);
+    else if (in_path.ends_with(".sub"))
+        write_sub_split(in_path.c_str(), out_path.c_str(), slope, offsets, mapping);
 }
 
 static bool number(const char* text, double& into) {
@@ -304,7 +331,7 @@ static void report(const Report& r) {
 }
 
 void usage() {
-    std::cerr << "Usage: lapse <video_or_subtitle> <subtitle> [auto|ols|nosplit|split] [penalty] [--output <path>] [--no-backup] [--no-sidecar] [--no-embedded] [--full-scan] [--no-cache] [--force] [--json] [--quiet] [--dry-run] [--strict] [--confidence N] [--audio-track N] [--sub-track N]\n";
+    std::cerr << "Usage: lapse <video_or_subtitle> <subtitle> [auto|ols|nosplit|split] [penalty] [--output <path>] [--no-backup] [--no-sidecar] [--no-embedded] [--full-scan] [--no-cache] [--force] [--json] [--quiet] [--dry-run] [--strict] [--confidence N] [--audio-track N] [--sub-track N] [--fps N]\n";
     std::cerr << "       --confidence N   how far the answer has to stand out before the original is overwritten (default " << sure_sigma << ")\n";
     std::cerr << "       lapse --version\n";
     std::cerr << "       lapse --formats\n";
@@ -325,6 +352,7 @@ int run(int argc, const char *argv[]) {
     bool no_sidecar = false;
     int audio_track = -1;
     int sub_track = -1;
+    double fps = 0;
 
     for (int i = 1; i < argc; i++) {
         std::string arg = argv[i];
@@ -345,6 +373,10 @@ int run(int argc, const char *argv[]) {
             double got;
             if (i + 1 >= argc || !number(argv[++i], got)) { usage(); return -1; }
             sub_track = (int)got;
+        } else if (arg == "--fps") {
+            double got;
+            if (i + 1 >= argc || !number(argv[++i], got) || got < 10 || got > 120) { usage(); return -1; }
+            fps = got;
         } else if (arg == "--confidence") {
             double got;
             if (i + 1 >= argc || !number(argv[++i], got) || got <= 0) {
@@ -416,6 +448,28 @@ int run(int argc, const char *argv[]) {
     std::vector<std::pair<int,int>> ref_spans;
     std::vector<float> ref_weights;
     double ref_coverage = 1.0;
+
+    // MicroDVD counts frames, not time, so nothing in the file means anything
+    // until we know the rate. Ask the video, it is the one the frames get
+    // counted against, then whatever the subtitle says about itself. A rate we
+    // made up would land every cue in the wrong place, so we stop instead
+    if (input_path.ends_with(".sub") || ref_path.ends_with(".sub")) {
+        if (fps <= 0 && !is_subtitle(ref_path)) fps = probe_fps(ref_path.c_str());
+        set_sub_fps(fps);
+
+        std::string which = input_path.ends_with(".sub") ? input_path : ref_path;
+        double used = sub_fps(load_text(which));
+        if (used <= 0 && is_subtitle(ref_path)) {
+            used = fps_from_length(which, which == ref_path ? input_path : ref_path);
+            set_sub_fps(used);
+        }
+        if (used <= 0) {
+            std::cerr << "Cannot tell what frame rate " << which << " counts in. "
+                      << "It has no {1}{1} line and there is no video to ask, so pass --fps N\n";
+            return 1;
+        }
+        say() << "MicroDVD frames at " << used << " fps\n";
+    }
 
     std::vector<std::pair<int,int>> timestamps = read_subtitle(input_path);
 
@@ -600,6 +654,8 @@ int run(int argc, const char *argv[]) {
                 write_ass_OLS(input_path.c_str(), output_path.c_str(), slope, intercept);
             else if (input_path.ends_with(".vtt"))
                 write_vtt_OLS(input_path.c_str(), output_path.c_str(), slope, intercept);
+            else if (input_path.ends_with(".sub"))
+                write_sub_OLS(input_path.c_str(), output_path.c_str(), slope, intercept);
         }
         report(card);
         return (verdict != Verdict::Solid && !force) ? 3 : 0;

--- a/engine/main.cpp
+++ b/engine/main.cpp
@@ -331,7 +331,7 @@ static void report(const Report& r) {
 }
 
 void usage() {
-    std::cerr << "Usage: lapse <video_or_subtitle> <subtitle> [auto|ols|nosplit|split] [penalty] [--output <path>] [--no-backup] [--no-sidecar] [--no-embedded] [--full-scan] [--no-cache] [--force] [--json] [--quiet] [--dry-run] [--strict] [--confidence N] [--audio-track N] [--sub-track N] [--fps N]\n";
+    std::cerr << "Usage: lapse <video_or_subtitle> [subtitle] [auto|ols|nosplit|split] [penalty] [--output <path>] [--no-backup] [--no-sidecar] [--no-embedded] [--full-scan] [--no-cache] [--force] [--json] [--quiet] [--dry-run] [--strict] [--confidence N] [--audio-track N] [--sub-track N] [--fps N]\n";
     std::cerr << "       --confidence N   how far the answer has to stand out before the original is overwritten (default " << sure_sigma << ")\n";
     std::cerr << "       lapse --version\n";
     std::cerr << "       lapse --formats\n";
@@ -417,6 +417,25 @@ int run(int argc, const char *argv[]) {
         } else {
             args.push_back(arg);
         }
+    }
+
+    if (args.size() == 1 && !is_subtitle(args[0])) {
+        std::string got = embedded_text(args[0].c_str(), sub_track);
+        if (got.empty()) {
+            std::cerr << "No subtitles inside " << args[0] << " to take out\n";
+            return 1;
+        }
+        std::string put = args[0].substr(0, args[0].find_last_of('.')) + ".lapse.srt";
+        std::ofstream file(put, std::ios::binary);
+        if (!file) {
+            std::cerr << "Cannot write " << put << '\n';
+            return 1;
+        }
+        file << got;
+        file.close();
+        args.push_back(put);
+        use_embedded = false;
+        say() << "Wrote " << put << '\n';
     }
 
     if (args.size() < 2) {

--- a/engine/srt_parser.cpp
+++ b/engine/srt_parser.cpp
@@ -105,6 +105,60 @@ int parse_timestamp(const std::string& line, size_t from) {
     return (int)ms;
 }
 
+// A MicroDVD line is {start}{end}text, both frame numbers. Gives back where the
+// text begins so the writer can put the same line back together
+bool sub_frames(const std::string& line, long long& a, long long& b, size_t& text_from) {
+    if (line.empty() || line[0] != '{') return false;
+    size_t one = line.find('}');
+    if (one == std::string::npos || one + 1 >= line.size() || line[one + 1] != '{') return false;
+    size_t two = line.find('}', one + 2);
+    if (two == std::string::npos) return false;
+
+    a = atoll(line.substr(1, one - 1).c_str());
+    b = atoll(line.substr(one + 2, two - one - 2).c_str());
+    text_from = two + 1;
+    return true;
+}
+
+// What the video runs at, once somebody has looked it up. That beats anything
+// the subtitle claims about itself, since the frames get counted against that
+// video in the end
+static double known_fps = 0;
+
+void set_sub_fps(double fps) {
+    known_fps = (fps >= 10 && fps <= 120) ? fps : 0;
+}
+
+// Frames only mean something once we know the rate. MicroDVD files declare it
+// as the text of a {1}{1} line at the top. Zero when nobody ever said, and
+// then we are not going to invent one
+double sub_fps(const std::string& text) {
+    if (known_fps > 0) return known_fps;
+
+
+    std::istringstream ss(text);
+    std::string line;
+    while (getline(ss, line)) {
+        strip_bom(line);
+        if (trim(line).empty()) continue;
+
+        long long a, b;
+        size_t text_from;
+        if (!sub_frames(line, a, b, text_from)) break;
+        double fps = atof(trim(line.substr(text_from)).c_str());
+        if (a <= 1 && b <= 1 && fps >= 10 && fps <= 120) return fps;
+        break;
+    }
+    return 0;
+}
+
+int frames_to_ms(long long frame, double fps) {
+    if (frame < 0 || fps <= 0) return -1;
+    long long ms = (long long)(frame * 1000.0 / fps + 0.5);
+    if (ms > MAX_TIME_MS) return -1;
+    return (int)ms;
+}
+
 std::vector<std::pair<int,int>> read_subtitle(const std::string& path) {
     if (path.ends_with(".srt"))
         return read_srt(path.c_str());
@@ -112,6 +166,8 @@ std::vector<std::pair<int,int>> read_subtitle(const std::string& path) {
         return read_ass(path.c_str());
     if (path.ends_with(".vtt"))
         return read_vtt(path.c_str());
+    if (path.ends_with(".sub"))
+        return read_sub(path.c_str());
     throw std::runtime_error("Unsupported subtitle format: " + path);
 }
 
@@ -226,6 +282,37 @@ std::vector<std::pair<int, int>> read_ass(const char* filename) {
 // vtt cues look just like srt ones once we stop counting characters
 std::vector<std::pair<int,int>> read_vtt(const char* filename) {
     return read_srt(filename);
+}
+
+std::vector<std::pair<int,int>> read_sub(const char* filename) {
+    std::vector<std::pair<int,int>> timestamps;
+    std::string text = load_text(filename);
+    double fps = sub_fps(text);
+    std::istringstream read_file(text);
+    std::string line {};
+    bool first = true;
+
+    while (getline(read_file, line)) {
+        if (first) { strip_bom(line); first = false; }
+
+        long long a, b;
+        size_t text_from;
+        if (!sub_frames(line, a, b, text_from)) continue;
+
+        if ((int)timestamps.size() >= MAX_CUES) {
+            say() << "Stopping at " << MAX_CUES << " cues, the rest of this file is left where it is\n";
+            break;
+        }
+
+        int start_ms = frames_to_ms(a, fps);
+        int end_ms   = frames_to_ms(b, fps);
+
+        if (start_ms < 0 || end_ms < 0)
+            timestamps.push_back({0, 0});
+        else
+            timestamps.push_back({start_ms, end_ms});
+    }
+    return timestamps;
 }
 
 

--- a/engine/srt_parser.h
+++ b/engine/srt_parser.h
@@ -30,10 +30,16 @@ std::vector<size_t> ass_commas(const std::string& line);
 bool ass_field(const std::string& line, const std::vector<size_t>& commas, int index, size_t& from, size_t& len);
 std::pair<int,int> ass_time_columns(const std::string& format_line);
 
+bool sub_frames(const std::string& line, long long& a, long long& b, size_t& text_from);
+double sub_fps(const std::string& text);
+void set_sub_fps(double fps);
+int frames_to_ms(long long frame, double fps);
+
 std::vector<std::pair<int,int>> read_subtitle(const std::string& path);
 std::vector<std::pair<int, int>> read_srt(const char* filename);
 std::vector<std::pair<int, int>> read_ass(const char* filename);
 std::vector<std::pair<int,int>> read_vtt(const char* filename);
+std::vector<std::pair<int,int>> read_sub(const char* filename);
 std::pair<std::vector<std::pair<int,int>>, std::vector<int>> process_spans(const std::vector<std::pair<int, int>>& timestamps, bool merge = true, bool sort_by_time = true);
 const float SPEECH_THRESHOLD = 0.25f;
 const int MIN_CUES = 10;

--- a/engine/write_subtitle.cpp
+++ b/engine/write_subtitle.cpp
@@ -80,6 +80,11 @@ static std::string ms_to_ass_ts(int ms) {
     return buf;
 }
 
+static std::string ms_to_frames(int ms, double fps) {
+    if (ms < 0) ms = 0;
+    return std::to_string((long long)(ms * fps / 1000.0 + 0.5));
+}
+
 // srt and vtt are the same file with a different character in front of the
 // milliseconds, so they go through here together. We write to a temp file and
 // move it into place at the end if something throws halfway the subtitle the user already had is still whole
@@ -180,6 +185,51 @@ static void write_dialogue(const char* input_path, const char* output_path, cons
     save_file(output_path, out);
 }
 
+// MicroDVD lines get counted in frames, so the times go back out through the
+// rate the file was read at. The {1}{1} line at the top is the rate itself and
+// has to stay where it is
+static void write_frames(const char* input_path, const char* output_path, const Shift& shift) {
+    std::string text = load_file(input_path);
+    double fps = sub_fps(text);
+    bool ends_clean = !text.empty() && text.back() == '\n';
+    std::istringstream ss(text);
+
+    std::string out;
+
+    std::string line;
+    int cue = 0;
+    const char* eol = "\n";
+    while (std::getline(ss, line)) {
+        if (!line.empty() && line.back() == '\r') {
+            line.pop_back();
+            eol = "\r\n";
+        }
+
+        long long a, b;
+        size_t text_from;
+        if (sub_frames(line, a, b, text_from)) {
+            int start_ms = frames_to_ms(a, fps);
+            int end_ms   = frames_to_ms(b, fps);
+            bool rate_line = (cue == 0 && a <= 1 && b <= 1);
+
+            // the frames we are about to write mean this rate, so say so
+            if (rate_line) {
+                char rate[32];
+                snprintf(rate, sizeof(rate), "%.3f", fps);
+                line = "{1}{1}" + std::string(rate);
+            } else if (start_ms >= 0 && end_ms >= 0)
+                line = "{" + ms_to_frames(shift.apply(start_ms, cue), fps) + "}{" +
+                       ms_to_frames(shift.apply(end_ms, cue), fps) + "}" + line.substr(text_from);
+            cue++;
+        }
+
+        out += line;
+        if (ends_clean || !ss.eof()) out += eol;
+    }
+
+    save_file(output_path, out);
+}
+
 static Shift one_line(double slope, double intercept_s) {
     Shift shift;
     shift.slope = slope;
@@ -207,6 +257,10 @@ void write_ass_OLS(const char* input_path, const char* output_path, double slope
     write_dialogue(input_path, output_path, one_line(slope, intercept_s));
 }
 
+void write_sub_OLS(const char* input_path, const char* output_path, double slope, double intercept_s) {
+    write_frames(input_path, output_path, one_line(slope, intercept_s));
+}
+
 void write_srt_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping) {
     write_cues(input_path, output_path, ',', per_cue(slope, offsets, mapping));
 }
@@ -217,4 +271,8 @@ void write_vtt_split(const char* input_path, const char* output_path, double slo
 
 void write_ass_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping) {
     write_dialogue(input_path, output_path, per_cue(slope, offsets, mapping));
+}
+
+void write_sub_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping) {
+    write_frames(input_path, output_path, per_cue(slope, offsets, mapping));
 }

--- a/engine/write_subtitle.h
+++ b/engine/write_subtitle.h
@@ -27,6 +27,8 @@ void backup_file(const char* path);
 void write_srt_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
 void write_ass_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
 void write_vtt_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
+void write_sub_OLS(const char* input_path, const char* output_path, double slope, double intercept_s);
 void write_srt_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping);
 void write_ass_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping);
 void write_vtt_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping);
+void write_sub_split(const char* input_path, const char* output_path, double slope, const std::vector<int>& offsets, const std::vector<int>& mapping);


### PR DESCRIPTION
## Summary
- Reads and writes MicroDVD (`.sub`), frame numbers in, frame numbers out
- `lapse video.mkv` on its own now pulls the embedded subtitle track out, syncs it, and leaves it as a sidecar srt next to the video

## Test plan
- [ ] Sync a `.sub` against an srt reference, both directions
- [ ] Sync a `.sub` against a video with no declared frame rate
- [ ] `lapse video.mkv` with an embedded srt/ass/mov_text track produces a synced sidecar