### PR TITLE
Let the engine settings be changed from the web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ From there you can:
 - **Leave folders out.** Everything you mounted is listed, one level down. Untick what you do not want touched and the scanner walks past it. Paths deeper than that can be typed in.
 - **Translate.** Select subtitles, give a language code and send them off. See `Translation` below.
 - **Light or dark.** The button in the corner follows whatever your system is set to until you press it, and then it stays on what you picked. The choice is kept in the browser, so each device has its own.
+- **Change the engine settings.** Mode, file output, confidence and every switch the CLI takes, under Settings. See `Engine settings` below.
 
 The library list filters by status, by name and by confidence, so `Confidence under 5` is a quick way to find the results that did not stand out much and are worth looking at.
 
@@ -180,6 +181,15 @@ Everything the CLI takes is available in the container. Switches are `0` or `1`,
 | `AUDIO_TRACK` | `--audio-track` | Which audio track to listen to |
 | `SUB_TRACK` | `--sub-track` | Which embedded subtitle track to use as reference |
 | `FPS` | `--fps` | Frame rate for frame based subtitles that do not carry one |
+
+All of it is in the web interface as well, under Settings, and what you save there is used from the next scan onwards. `OUTPUT_SUFFIX` and `NO_BACKUP` are the two halves of the file output picker there:
+
+| File output | What happens |
+|---|---|
+| Write a new file | The original is left alone. `Movie.en.srt` gets `Movie.en.synced.srt` beside it |
+| Write a new file, keep a backup | Same, and a copy of the original is kept as `.bak` as well |
+| Overwrite, keep a backup | The subtitle is replaced and the old one is kept as `.bak`. Default |
+| Overwrite, no backup | The subtitle is replaced and nothing is kept |
 
 `OUTPUT_SUFFIX` is the way to keep a library untouched. The original stays as it is, the synced copy lands beside it, and files the container wrote itself are skipped on later scans. Pair it with `NO_BACKUP=1` if you would rather not collect `.bak` files as well.
 

--- a/docker/index.html
+++ b/docker/index.html
@@ -146,6 +146,11 @@
   .folders label.root span { font-weight: 550; }
   .hint { color: var(--dim); font-size: 13px; margin: 0 0 14px; }
   #theme { min-width: 74px; }
+
+  .switches { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 4px; margin: 14px 0; }
+  .switches label { display: flex; gap: 9px; align-items: center; padding: 5px 7px; border-radius: 6px; }
+  .switches label:hover { background: var(--line-soft); }
+  .row + .row { margin-top: 10px; }
   @media (max-width: 720px) { .drop { display: none; } main { padding: 16px; } header, nav { padding-left: 16px; padding-right: 16px; } }
 </style>
 <script>
@@ -242,6 +247,56 @@ matchMedia("(prefers-color-scheme: dark)").onchange = paintTheme;
 
   <div id="settings" hidden>
     <div class="card">
+      <h2>Engine</h2>
+      <div class="body" id="engine">
+        <p class="hint">What the engine is told on every run. The environment variables are the starting point, what you save here wins from then on.</p>
+        <div class="bar row">
+          <label class="inline" for="mode">Mode</label>
+          <select id="mode">
+            <option value="auto">Work it out</option>
+            <option value="nosplit">One offset for the whole file</option>
+            <option value="ols">Offset and drift</option>
+            <option value="split">Split into parts</option>
+          </select>
+          <label class="inline" for="penalty">Split penalty</label>
+          <input type="number" id="penalty" min="0" step="1" style="width: 80px">
+          <label class="inline" for="confidence">Confidence</label>
+          <input type="number" id="confidence" min="0" step="0.5" placeholder="default" style="width: 92px">
+        </div>
+        <div class="bar row">
+          <label class="inline" for="output">File output</label>
+          <select id="output">
+            <option value="new">Write a new file</option>
+            <option value="new_backup">Write a new file, keep a backup</option>
+            <option value="overwrite_backup">Overwrite, keep a backup</option>
+            <option value="overwrite">Overwrite, no backup</option>
+          </select>
+          <input type="text" id="suffix" placeholder=".synced" style="width: 110px">
+        </div>
+        <div class="bar row">
+          <label class="inline" for="audio_track">Audio track</label>
+          <input type="number" id="audio_track" min="0" step="1" placeholder="default" style="width: 92px">
+          <label class="inline" for="sub_track">Subtitle track</label>
+          <input type="number" id="sub_track" min="0" step="1" placeholder="default" style="width: 92px">
+          <label class="inline" for="fps">Frame rate</label>
+          <input type="number" id="fps" min="10" max="120" step="0.001" placeholder="from video" style="width: 110px">
+        </div>
+        <div class="switches">
+          <label><input type="checkbox" id="force"><span>Sync even when there is little to go on</span></label>
+          <label><input type="checkbox" id="strict"><span>Write nothing rather than an unsure guess</span></label>
+          <label><input type="checkbox" id="no_sidecar"><span>No unsure file beside the original</span></label>
+          <label><input type="checkbox" id="no_embedded"><span>Ignore subtitle tracks inside the video</span></label>
+          <label><input type="checkbox" id="no_cache"><span>Listen to the video every time</span></label>
+          <label><input type="checkbox" id="full_scan"><span>Listen to the whole video</span></label>
+          <label><input type="checkbox" id="dry_run"><span>Work it out and write nothing</span></label>
+        </div>
+        <div class="bar">
+          <button id="saveEngine" class="solid">Save engine settings</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
       <h2>Scanning</h2>
       <div class="body">
         <p class="hint">New files are picked up as they land. This is how often the whole library is walked again to catch anything the file events missed.</p>
@@ -272,6 +327,8 @@ matchMedia("(prefers-color-scheme: dark)").onchange = paintTheme;
 <script>
 const $ = id => document.getElementById(id);
 const LABELS = { done: "Synced", lowconf: "Unsure", failed: "Failed", undone: "Put back" };
+const SWITCHES = ["force", "strict", "no_sidecar", "no_embedded", "no_cache", "full_scan", "dry_run"];
+const NUMBERS = ["penalty", "confidence", "audio_track", "sub_track", "fps"];
 
 let data = null;
 let excluded = [];
@@ -420,6 +477,24 @@ function drawTranslations() {
     </tr>`).join("") : `<tr><td colspan="4" class="empty">Nothing translated yet</td></tr>`;
 }
 
+function showSuffix() {
+  $("suffix").hidden = !$("output").value.startsWith("new");
+}
+
+function drawEngine() {
+  const engine = data.engine;
+  if (editing || !engine.mode) return;
+
+  $("mode").value = engine.mode;
+  $("suffix").value = engine.suffix || "";
+  $("output").value = engine.suffix
+    ? (engine.no_backup ? "new" : "new_backup")
+    : (engine.no_backup ? "overwrite" : "overwrite_backup");
+  NUMBERS.forEach(name => $(name).value = engine[name] || "");
+  SWITCHES.forEach(name => $(name).checked = !!engine[name]);
+  showSuffix();
+}
+
 function render(fresh) {
   data = fresh;
   if (!editing) excluded = fresh.excluded.slice();
@@ -434,6 +509,7 @@ function render(fresh) {
   drawFolders();
   drawRows();
   drawTranslations();
+  drawEngine();
 }
 
 const TABS = ["library", "translations", "settings"];
@@ -506,6 +582,24 @@ $("addPath").onclick = () => {
 };
 
 $("saveFolders").onclick = () => send("/api/excluded", { paths: excluded });
+
+$("engine").oninput = () => editing = true;
+$("engine").onchange = () => { editing = true; showSuffix(); };
+
+$("saveEngine").onclick = () => {
+  const output = $("output").value;
+  let suffix = $("suffix").value.trim() || ".synced";
+  if (!suffix.startsWith(".")) suffix = "." + suffix;
+
+  const engine = {
+    mode: $("mode").value,
+    suffix: output.startsWith("new") ? suffix : "",
+    no_backup: output === "new" || output === "overwrite"
+  };
+  NUMBERS.forEach(name => engine[name] = $(name).value.trim());
+  SWITCHES.forEach(name => engine[name] = $(name).checked);
+  send("/api/engine", { engine });
+};
 
 $("undo").onclick = () => {
   const ids = picked();

--- a/docker/main.py
+++ b/docker/main.py
@@ -40,7 +40,6 @@ MAX_ATTEMPTS   = int(os.environ.get("MAX_ATTEMPTS", "3"))
 TIMEOUT        = int(os.environ.get("TIMEOUT", "1800"))
 POLLING        = os.environ.get("POLLING", "0") == "1"
 OUTPUT_SUFFIX  = os.environ.get("OUTPUT_SUFFIX", "").strip()
-DRY_RUN        = os.environ.get("DRY_RUN", "0") == "1"
 CACHE_DAYS     = int(os.environ.get("CACHE_DAYS", "30"))
 CACHE_DIR      = os.environ.get("LAPSE_CACHE") or os.path.join(os.path.dirname(DB_PATH) or ".", "cache")
 WEB            = os.environ.get("WEB", "1") == "1"
@@ -97,7 +96,7 @@ LANGUAGE_WORDS = {
 
 jobs = queue.Queue()
 running = True
-ENGINE_FLAGS = []
+ENGINE = {}
 EXCLUDED = []
 
 engine = None
@@ -121,13 +120,34 @@ def halt():
         threading.Timer(5, force, [child]).start()
 
 
+def engine_defaults():
+    options = {"mode": MODE, "penalty": PENALTY, "suffix": OUTPUT_SUFFIX}
+    for name, option in SWITCHES:
+        options[name.lower()] = os.environ.get(name, "0") == "1"
+    for name, option in VALUES:
+        options[name.lower()] = os.environ.get(name, "").strip()
+    return options
+
+
+def engine_options(conn):
+    options = engine_defaults()
+    options.update(json.loads(setting(conn, "engine", "{}")))
+    return options
+
+
+def save_engine(conn, options):
+    conn.execute("INSERT OR REPLACE INTO settings (key, value) VALUES ('engine', ?)",
+                 (json.dumps(options),))
+    conn.commit()
+
+
 def engine_flags():
     flags = []
     for name, option in SWITCHES:
-        if os.environ.get(name, "0") == "1":
+        if ENGINE.get(name.lower()):
             flags.append(option)
     for name, option in VALUES:
-        value = os.environ.get(name, "").strip()
+        value = str(ENGINE.get(name.lower()) or "").strip()
         if value:
             flags += [option, value]
     return flags
@@ -161,10 +181,11 @@ def drop_leftovers(*paths):
 
 
 def output_for(srt_path):
-    if not OUTPUT_SUFFIX:
+    suffix = ENGINE.get("suffix") or ""
+    if not suffix:
         return None
     base, ext = os.path.splitext(srt_path)
-    return base + OUTPUT_SUFFIX + ext
+    return base + suffix + ext
 
 
 def engine_formats():
@@ -265,7 +286,8 @@ def normalize(name):
 def ours(base):
     if base.endswith(".lapse-unsure") or base.endswith(".lapse"):
         return True
-    return bool(OUTPUT_SUFFIX) and base.endswith(OUTPUT_SUFFIX)
+    suffix = ENGINE.get("suffix") or ""
+    return bool(suffix) and base.endswith(suffix)
 
 
 def subtitle_tokens(base):
@@ -430,10 +452,11 @@ def parse_output(output):
 
 
 def run_sync(video_path, srt_path):
-    command = [LAPSE, video_path, srt_path, MODE, "--json"]
-    if MODE == "split":
-        command.insert(4, PENALTY)
-    command += ENGINE_FLAGS
+    mode = ENGINE.get("mode") or MODE
+    command = [LAPSE, video_path, srt_path, mode, "--json"]
+    if mode == "split":
+        command.insert(4, str(ENGINE.get("penalty") or PENALTY))
+    command += engine_flags()
 
     output = output_for(srt_path)
     if output:
@@ -528,11 +551,11 @@ def process(conn, video_path, srt_path):
         return "stopped"
     except Exception as e:
         print("Failed:", srt_path, "->", e)
-        if not DRY_RUN:
+        if not ENGINE.get("dry_run"):
             save_result(conn, video_path, srt_path, None, {}, attempts, "failed")
         return "failed"
 
-    if DRY_RUN:
+    if ENGINE.get("dry_run"):
         return "dryrun"
 
     backup_path = srt_path + ".bak"
@@ -554,7 +577,7 @@ def process(conn, video_path, srt_path):
     if status == "done" and MIN_CONFIDENCE > 0 and confidence is not None \
             and confidence < MIN_CONFIDENCE:
         written_to = values.get("output")
-        if OUTPUT_SUFFIX and written_to and written_to != srt_path:
+        if ENGINE.get("suffix") and written_to and written_to != srt_path:
             os.remove(written_to)
             print("Confidence %.2f is under %.2f, threw the result away: %s" % (confidence, MIN_CONFIDENCE, written_to))
             status = "lowconf"
@@ -575,12 +598,13 @@ def process(conn, video_path, srt_path):
 
 
 def run_scan(conn, path, verbose=False):
-    global EXCLUDED
+    global EXCLUDED, ENGINE
 
     if not os.path.isdir(path):
         return
 
     EXCLUDED = json.loads(setting(conn, "excluded", "[]"))
+    ENGINE = engine_options(conn)
     if blocked(path):
         return
 
@@ -680,7 +704,7 @@ def stop(signum, frame):
 
 
 def main():
-    global ENGINE_FORMATS, SUBTITLE_EXTS, ENGINE_FLAGS
+    global ENGINE_FORMATS, SUBTITLE_EXTS, ENGINE
 
     signal.signal(signal.SIGTERM, stop)
     signal.signal(signal.SIGINT, stop)
@@ -689,12 +713,16 @@ def main():
     os.environ["LAPSE_CACHE"] = CACHE_DIR
     prune_cache()
 
-    ENGINE_FLAGS = engine_flags()
-    if ENGINE_FLAGS:
-        print("Engine flags:", " ".join(ENGINE_FLAGS))
-    if OUTPUT_SUFFIX:
-        print("Writing results as name%s.ext beside the original" % OUTPUT_SUFFIX)
-    if DRY_RUN:
+    conn = init_db()
+    ENGINE = engine_options(conn)
+    save_engine(conn, ENGINE)
+
+    flags = engine_flags()
+    if flags:
+        print("Engine flags:", " ".join(flags))
+    if ENGINE["suffix"]:
+        print("Writing results as name%s.ext beside the original" % ENGINE["suffix"])
+    if ENGINE["dry_run"]:
         print("Dry run, nothing will be written or recorded")
 
     ENGINE_FORMATS = engine_formats()
@@ -702,7 +730,6 @@ def main():
     print("Engine reads:", " ".join(sorted(ENGINE_FORMATS)))
     print("Library:", ", ".join(MEDIA_ROOTS))
 
-    conn = init_db()
     observer = start_watching()
 
     server = None

--- a/docker/web.py
+++ b/docker/web.py
@@ -85,6 +85,7 @@ def state():
             "targets": translate.TARGETS,
             "waiting": waiting.qsize(),
         },
+        "engine": json.loads(setting(conn, "engine", "{}")),
         "interval": int(setting(conn, "scan_interval", config["interval"])),
         "excluded": json.loads(setting(conn, "excluded", "[]")),
         "folders": folders(),
@@ -174,6 +175,12 @@ def act(path, body):
                 config["halt"]()
         elif path == "/api/interval":
             save_setting(conn, "scan_interval", max(0, int(body.get("seconds", 0))))
+        elif path == "/api/engine":
+            saved = json.loads(setting(conn, "engine", "{}"))
+            for key, value in (body.get("engine") or {}).items():
+                if key in saved:
+                    saved[key] = value
+            save_setting(conn, "engine", json.dumps(saved))
         elif path == "/api/excluded":
             paths = [p.strip() for p in body.get("paths", []) if isinstance(p, str) and p.strip()]
             save_setting(conn, "excluded", json.dumps(sorted(set(paths))))


### PR DESCRIPTION
Everything the CLI takes was environment only, so changing a switch meant editing the compose file and restarting the container. The Settings tab now has the lot: mode, split penalty, confidence, the four ways the output can be written, the track and frame rate fields, and the switches.

Defaults still come from the environment. What is saved goes in the database and is picked up on the next scan.