### PR TITLE
Rework the interface and add reference sync, convert and film counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,9 @@ From there you can:
 - **Translate.** Select subtitles, give a language code and send them off. See `Translation` below.
 - **Light or dark.** The button in the corner follows whatever your system is set to until you press it, and then it stays on what you picked. The choice is kept in the browser, so each device has its own.
 - **Shift.** Move a subtitle by hand, in milliseconds, for when a sync came out close but not quite right. The first cues are shown before and after as you type, and you pick whether the result lands beside the original or over it. Nothing is decoded and the engine is not involved, so it is instant. `.srt`, `.vtt`, `.ass` and `.ssa`.
+- **Sync subtitles to reference.** For items with several subtitle tracks where one is already correct. Lines every other track up against it, or just the one track you pick. Skips the audio entirely, so it is fast and usually more accurate than syncing each track on its own.
+- **Convert.** Write a subtitle out as `.srt`, `.vtt`, `.ass` or `.ssa`, leaving the original where it is unless you tick the box. An existing file at the new name is kept as `.bak` first.
+- **Film counts.** The line under the tiles says how many films are fully synced, partly synced or untouched. Subtitle tracks inside the video are left out of that sum by default, so a film with two external subtitles that are both synced counts as fully synced even when the container holds eight more. Tick `Count embedded tracks too` to have them count against it instead.
 - **Change the engine settings.** Mode, file output, confidence and every switch the CLI takes, under Settings. See `Engine settings` below.
 
 The library list filters by status, by name and by confidence, so `Confidence under 5` is a quick way to find the results that did not stand out much and are worth looking at.

--- a/docker/index.html
+++ b/docker/index.html
@@ -7,31 +7,35 @@
 <style>
   :root {
     color-scheme: light;
-    --bg: #f6f6f4;
+    --bg: #f5f7fa;
     --panel: #ffffff;
-    --line: #e3e2de;
-    --line-soft: #eeedea;
-    --text: #26241f;
-    --dim: #78746c;
-    --accent: #3c6e63;
-    --accent-soft: #eef3f1;
-    --good: #3f7d58;
-    --warn: #9a6b1f;
-    --bad: #a8443c;
+    --line: #dcdcdc;
+    --line-soft: #eff1f3;
+    --text: #515253;
+    --dim: #7f8285;
+    --accent: #5799ef;
+    --accent-soft: #e4eefb;
+    --bar: #3a3f51;
+    --barText: #dfe0e2;
+    --good: #27c24c;
+    --warn: #ffa500;
+    --bad: #f05050;
   }
   :root[data-theme="dark"] {
     color-scheme: dark;
-    --bg: #17181a;
-    --panel: #1e1f22;
-    --line: #2e3034;
-    --line-soft: #26282b;
-    --text: #e4e3df;
-    --dim: #918d86;
-    --accent: #7fb3a4;
-    --accent-soft: #232a29;
-    --good: #7fb18d;
-    --warn: #c9a05c;
-    --bad: #d18a83;
+    --bg: #1f2225;
+    --panel: #2a2d30;
+    --line: #3a3f44;
+    --line-soft: #303438;
+    --text: #cccccc;
+    --dim: #8c9296;
+    --accent: #5799ef;
+    --accent-soft: #2f3b4b;
+    --bar: #23272a;
+    --barText: #cccccc;
+    --good: #27c24c;
+    --warn: #ffa500;
+    --bad: #f05050;
   }
   * { box-sizing: border-box; }
   body {
@@ -44,67 +48,76 @@
   header {
     display: flex;
     align-items: center;
-    gap: 14px;
+    gap: 12px;
     flex-wrap: wrap;
-    padding: 14px 24px;
-    background: var(--panel);
-    border-bottom: 1px solid var(--line);
+    padding: 9px 18px;
+    background: var(--bar);
+    color: var(--barText);
+    border-bottom: 1px solid #000;
   }
-  .mark { font-size: 16px; font-weight: 600; letter-spacing: .14em; margin-right: auto; }
-  .state { display: flex; align-items: center; gap: 7px; color: var(--dim); font-size: 13px; }
-  .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--good); }
-  .dot.off { background: var(--warn); }
-  .dot.gone { background: var(--bad); }
+  .mark { font-size: 15px; font-weight: 700; letter-spacing: .18em; margin-right: auto; }
+  .state { display: flex; align-items: center; gap: 7px; color: var(--dim); font-size: 12px; }
+  header .state { color: #9aa0a6; }
 
-  nav { display: flex; gap: 4px; padding: 0 24px; background: var(--panel); border-bottom: 1px solid var(--line); }
+  nav { display: flex; padding: 0 18px; background: var(--panel); border-bottom: 1px solid var(--line); }
   nav button {
     background: none;
     border: 0;
-    border-bottom: 2px solid transparent;
+    border-bottom: 3px solid transparent;
     border-radius: 0;
     color: var(--dim);
-    padding: 11px 2px 9px;
-    margin: 0 18px -1px 0;
+    padding: 10px 0 7px;
+    margin: 0 20px -1px 0;
     font: inherit;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: .05em;
     cursor: pointer;
   }
-  nav button.on { color: var(--text); border-bottom-color: var(--accent); }
+  nav button.on { color: var(--accent); border-bottom-color: var(--accent); }
 
-  main { padding: 24px; max-width: 1180px; margin: 0 auto; }
-  .card { background: var(--panel); border: 1px solid var(--line); border-radius: 10px; }
-  .card + .card { margin-top: 18px; }
+  main { padding: 16px; max-width: 1400px; margin: 0 auto; }
+  .card { background: var(--panel); border: 1px solid var(--line); border-radius: 2px; }
+  .card + .card { margin-top: 14px; }
   .card h2 {
-    font-size: 12px;
+    font-size: 11px;
     letter-spacing: .09em;
     text-transform: uppercase;
     color: var(--dim);
-    font-weight: 600;
+    font-weight: 700;
     margin: 0;
-    padding: 15px 18px 0;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--line-soft);
+    background: var(--line-soft);
   }
-  .card .body { padding: 18px; }
+  .card .body { padding: 14px; }
 
   button, select, input[type=text], input[type=number] {
     font: inherit;
+    font-size: 13px;
     color: var(--text);
     background: var(--panel);
     border: 1px solid var(--line);
-    border-radius: 7px;
-    padding: 7px 11px;
+    border-radius: 2px;
+    padding: 5px 9px;
   }
+  header button { background: #4a5062; border-color: #22252d; color: var(--barText); }
   button { cursor: pointer; }
   button:hover:not(:disabled) { border-color: var(--dim); }
-  button.solid { background: var(--accent); border-color: var(--accent); color: var(--panel); }
+  button.solid { background: var(--accent); border-color: #4784d4; color: #fff; }
   button.solid:hover { opacity: .88; }
   button:disabled { opacity: .4; cursor: default; }
   input:focus, select:focus, button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 
-  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); gap: 1px; background: var(--line); border-radius: 10px; overflow: hidden; border: 1px solid var(--line); }
-  .tile { background: var(--panel); padding: 16px 18px; text-align: left; border: 0; border-radius: 0; cursor: pointer; }
+  .tiles { display: grid; grid-template-columns: repeat(auto-fit, minmax(110px, 1fr)); gap: 1px; background: var(--line); overflow: hidden; border: 1px solid var(--line); border-radius: 2px; }
+  .tile { background: var(--panel); padding: 12px 14px; text-align: left; border: 0; border-radius: 0; cursor: pointer; }
   .tile:hover { background: var(--line-soft); }
-  .tile.on { background: var(--accent-soft); }
-  .tile b { display: block; font-size: 24px; font-weight: 550; line-height: 1.2; font-variant-numeric: tabular-nums; }
-  .tile span { color: var(--dim); font-size: 12px; }
+  .tile.on { background: var(--accent-soft); box-shadow: inset 0 -3px 0 var(--accent); }
+  .tile b { display: block; font-size: 22px; font-weight: 400; line-height: 1.2; font-variant-numeric: tabular-nums; }
+  .tile span { color: var(--dim); font-size: 11px; text-transform: uppercase; letter-spacing: .04em; }
+
+  .films { display: flex; gap: 12px; align-items: center; flex-wrap: wrap; margin-top: 10px; font-size: 13px; color: var(--dim); }
+  .films label { display: flex; gap: 6px; align-items: center; }
 
   .bar { display: flex; gap: 9px; align-items: center; flex-wrap: wrap; }
   .bar .grow { flex: 1; min-width: 160px; }
@@ -125,16 +138,17 @@
   }
   thead th.sortable { cursor: pointer; user-select: none; }
   thead th.sortable:hover { color: var(--text); }
-  tbody td { padding: 10px; border-bottom: 1px solid var(--line-soft); vertical-align: top; }
+  tbody td { padding: 7px 10px; border-bottom: 1px solid var(--line-soft); vertical-align: top; font-size: 13px; }
+  tbody tr:nth-child(even) { background: var(--line-soft); }
   tbody tr:last-child td { border-bottom: 0; }
-  tbody tr:hover { background: var(--line-soft); }
-  .file { font-weight: 500; word-break: break-word; }
-  .path { color: var(--dim); font-size: 12px; word-break: break-all; }
+  tbody tr:hover { background: var(--accent-soft); }
+  .file { font-weight: 400; word-break: break-word; }
+  .path { color: var(--dim); font-size: 11px; word-break: break-all; }
   .num { text-align: right; white-space: nowrap; font-variant-numeric: tabular-nums; }
-  .tag { display: inline-block; font-size: 12px; padding: 2px 9px; border-radius: 999px; border: 1px solid currentColor; }
-  .tag.done { color: var(--good); }
-  .tag.lowconf, .tag.undone { color: var(--warn); }
-  .tag.failed { color: var(--bad); }
+  .tag { display: inline-block; font-size: 11px; padding: 2px 7px; border-radius: 2px; color: #fff; }
+  .tag.done { background: var(--good); }
+  .tag.lowconf, .tag.undone { background: var(--warn); }
+  .tag.failed { background: var(--bad); }
   .weak { color: var(--dim); }
   .empty { padding: 34px 10px; text-align: center; color: var(--dim); }
   .scroll { overflow-x: auto; }
@@ -147,7 +161,7 @@
   .hint { color: var(--dim); font-size: 13px; margin: 0 0 14px; }
   #theme { min-width: 74px; }
 
-  dialog { background: var(--panel); color: var(--text); border: 1px solid var(--line); border-radius: 10px; padding: 18px; width: min(580px, 92vw); }
+  dialog { background: var(--panel); color: var(--text); border: 1px solid var(--line); border-radius: 2px; padding: 16px; width: min(580px, 92vw); }
   dialog::backdrop { background: rgba(0, 0, 0, .45); }
   dialog h3 { margin: 0 0 4px; font-size: 15px; font-weight: 600; }
   .preview { margin: 14px 0; }
@@ -176,7 +190,6 @@ matchMedia("(prefers-color-scheme: dark)").onchange = paintTheme;
 
 <header>
   <span class="mark">LAPSE</span>
-  <span class="state"><i class="dot" id="dot"></i><span id="status">connecting</span></span>
   <span class="state" id="queued"></span>
   <button id="theme" title="Light, dark, or whatever the system is set to"></button>
   <button id="pause">Pause</button>
@@ -193,7 +206,12 @@ matchMedia("(prefers-color-scheme: dark)").onchange = paintTheme;
   <div id="library">
     <div class="tiles" id="tiles"></div>
 
-    <div class="card" style="margin-top: 18px">
+    <div class="films">
+      <span id="filmline"></span>
+      <label><input type="checkbox" id="countEmbedded"> Count embedded tracks too</label>
+    </div>
+
+    <div class="card" style="margin-top: 14px">
       <div class="body">
         <div class="bar">
           <input type="text" id="search" class="grow" placeholder="Search by name or folder">
@@ -202,6 +220,8 @@ matchMedia("(prefers-color-scheme: dark)").onchange = paintTheme;
           <span class="sep"></span>
           <button id="undo">Undo selected</button>
           <button id="shift">Shift selected</button>
+          <button id="convert">Convert selected</button>
+          <button id="toReference">Sync to reference</button>
           <button id="resync">Sync selected again</button>
           <button id="resyncAll">Sync everything again</button>
           <input type="text" id="language" placeholder="da" style="width: 70px">
@@ -353,6 +373,50 @@ matchMedia("(prefers-color-scheme: dark)").onchange = paintTheme;
   </div>
 </dialog>
 
+<dialog id="convertBox">
+  <h3>Convert subtitles</h3>
+  <p class="hint" id="convertFile"></p>
+  <div class="bar row">
+    <label class="inline" for="format">Write as</label>
+    <select id="format">
+      <option value=".srt">.srt</option>
+      <option value=".vtt">.vtt</option>
+      <option value=".ass">.ass</option>
+      <option value=".ssa">.ssa</option>
+    </select>
+    <label class="inline"><input type="checkbox" id="drop"> Remove the original once it is written</label>
+  </div>
+  <div class="bar row">
+    <span class="grow"></span>
+    <button id="convertClose">Cancel</button>
+    <button id="convertGo" class="solid">Convert</button>
+  </div>
+</dialog>
+
+<dialog id="referenceBox">
+  <h3>Sync subtitles to reference</h3>
+  <p class="hint" id="referenceFile"></p>
+  <div class="bar row">
+    <label class="inline" for="reference">Already correct</label>
+    <input type="text" id="reference" class="grow" list="referenceList">
+    <datalist id="referenceList"></datalist>
+  </div>
+  <div class="bar row">
+    <label class="inline"><input type="checkbox" id="referenceAll"> Do every other track in the same folder</label>
+  </div>
+  <div class="bar row">
+    <select id="referenceOutput">
+      <option value="new">Write a new file</option>
+      <option value="new_backup">Write a new file, keep a backup</option>
+      <option value="overwrite_backup" selected>Overwrite, keep a backup</option>
+      <option value="overwrite">Overwrite, no backup</option>
+    </select>
+    <span class="grow"></span>
+    <button id="referenceClose">Cancel</button>
+    <button id="referenceGo" class="solid">Sync</button>
+  </div>
+</dialog>
+
 <script>
 const $ = id => document.getElementById(id);
 const LABELS = { done: "Synced", lowconf: "Unsure", failed: "Failed", undone: "Put back" };
@@ -418,9 +482,9 @@ async function refresh() {
   try {
     const answer = await fetch("/api/state");
     render(await answer.json());
+    document.title = "lapse";
   } catch (e) {
-    $("status").textContent = "no connection";
-    $("dot").className = "dot gone";
+    document.title = "lapse (no connection)";
   }
 }
 
@@ -547,18 +611,28 @@ function render(fresh) {
   data = fresh;
   if (!editing) excluded = fresh.excluded.slice();
 
-  $("status").textContent = fresh.paused ? "paused" : "running";
-  $("dot").className = fresh.paused ? "dot off" : "dot";
   $("pause").textContent = fresh.paused ? "Resume" : "Pause";
   $("queued").textContent = fresh.queued ? fresh.queued + " folders queued" : "";
   if (document.activeElement !== $("interval")) $("interval").value = fresh.interval;
 
   drawTiles();
+  drawFilms();
   drawFolders();
   drawRows();
   drawTranslations();
   drawEngine();
 }
+
+function drawFilms() {
+  const f = data.films;
+  let text = f.total + " films, " + f.full + " fully synced";
+  if (f.part > 0) text = text + ", " + f.part + " partly";
+  if (f.none > 0) text = text + ", " + f.none + " not touched";
+  $("filmline").textContent = text;
+  if (document.activeElement !== $("countEmbedded")) $("countEmbedded").checked = data.count_embedded;
+}
+
+$("countEmbedded").onchange = () => send("/api/embedded", { on: $("countEmbedded").checked });
 
 const TABS = ["library", "translations", "settings"];
 
@@ -692,6 +766,52 @@ $("shiftGo").onclick = () => {
     ids: chosen,
     ms: Number($("shiftMs").value) || 0,
     output: $("shiftOutput").value
+  });
+};
+
+$("convert").onclick = () => {
+  chosen = picked();
+  if (!chosen.length) return alert("Pick a subtitle first");
+  $("convertFile").textContent = chosen.length === 1 ? "One subtitle" : chosen.length + " subtitles";
+  $("convertBox").showModal();
+};
+
+$("convertClose").onclick = () => $("convertBox").close();
+
+$("convertGo").onclick = () => {
+  $("convertBox").close();
+  send("/api/convert", { ids: chosen, format: $("format").value, drop: $("drop").checked });
+};
+
+$("toReference").onclick = async () => {
+  chosen = picked();
+  if (!chosen.length) return alert("Pick a subtitle first");
+
+  const got = await ask("/api/neighbours", { ids: chosen });
+  if (!got) return;
+
+  let options = "";
+  for (let i = 0; i < got.paths.length; i++) {
+    options = options + `<option value="${safe(got.paths[i])}">`;
+  }
+  $("referenceList").innerHTML = options;
+  $("reference").value = got.paths[0] || "";
+  $("referenceAll").checked = false;
+  $("referenceFile").textContent = chosen.length === 1
+    ? "One subtitle lined up against the one you pick"
+    : chosen.length + " subtitles lined up against the one you pick";
+  $("referenceBox").showModal();
+};
+
+$("referenceClose").onclick = () => $("referenceBox").close();
+
+$("referenceGo").onclick = () => {
+  $("referenceBox").close();
+  send("/api/reference", {
+    ids: chosen,
+    reference: $("reference").value.trim(),
+    everything: $("referenceAll").checked,
+    output: $("referenceOutput").value
   });
 };
 

--- a/docker/main.py
+++ b/docker/main.py
@@ -242,6 +242,12 @@ def init_db():
         )
     """)
     conn.execute("""
+        CREATE TABLE IF NOT EXISTS video_tracks (
+            video_path TEXT PRIMARY KEY,
+            tracks INTEGER
+        )
+    """)
+    conn.execute("""
         CREATE TABLE IF NOT EXISTS translations (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             source_path TEXT NOT NULL,
@@ -525,7 +531,33 @@ def our_translation(conn, path):
     return conn.execute("SELECT 1 FROM translations WHERE output_path = ?", (path,)).fetchone() is not None
 
 
+def count_tracks(video_path):
+    try:
+        result = subprocess.run(
+            ["ffprobe", "-v", "error", "-select_streams", "s",
+             "-show_entries", "stream=index", "-of", "csv=p=0", video_path],
+            capture_output=True, text=True, timeout=60)
+    except Exception:
+        return 0
+    found = 0
+    for line in (result.stdout or "").splitlines():
+        if line.strip():
+            found = found + 1
+    return found
+
+
+def remember_tracks(conn, video_path):
+    row = conn.execute("SELECT tracks FROM video_tracks WHERE video_path = ?",
+                       (video_path,)).fetchone()
+    if row is not None:
+        return
+    conn.execute("INSERT OR REPLACE INTO video_tracks (video_path, tracks) VALUES (?, ?)",
+                 (video_path, count_tracks(video_path)))
+    conn.commit()
+
+
 def process(conn, video_path, srt_path):
+    remember_tracks(conn, video_path)
     ext = os.path.splitext(srt_path)[1].lower()
     if ext not in ENGINE_FORMATS:
         return "unsupported"
@@ -735,7 +767,8 @@ def main():
     server = None
     if WEB:
         try:
-            server = web.start(WEB_PORT, jobs, MEDIA_ROOTS, DB_PATH, LAPSE, SCAN_INTERVAL, halt)
+            server = web.start(WEB_PORT, jobs, MEDIA_ROOTS, DB_PATH, LAPSE, SCAN_INTERVAL,
+                               halt, ENGINE_FORMATS)
             print("Web interface on port", WEB_PORT)
         except OSError as e:
             print("Could not open the web interface:", e)

--- a/docker/subs.py
+++ b/docker/subs.py
@@ -124,3 +124,134 @@ def save(path, lines, mode, suffix):
 def shift(path, ms, mode, suffix=".shifted"):
     ass = kind(path) in (".ass", ".ssa")
     return save(path, moved(read(path), ms, ass), mode, suffix)
+
+
+def text_cues(lines):
+    cues = []
+    for number, line in enumerate(lines):
+        if "-->" not in line:
+            continue
+        left, right = line.split("-->", 1)
+        start, end = to_ms(left), to_ms(right.strip())
+        if start is None or end is None:
+            continue
+        body = []
+        for after in lines[number + 1:]:
+            if not after.strip():
+                break
+            body.append(after.rstrip("\r\n"))
+        cues.append((start, end, body))
+    return cues
+
+
+def ass_cues(lines):
+    cues = []
+    for line in lines:
+        fields = dialogue(line)
+        if not fields:
+            continue
+        start, end = to_ms(fields[1]), to_ms(fields[2])
+        if start is None or end is None:
+            continue
+        text = re.sub(r"\{[^}]*\}", "", ",".join(fields[9:]).rstrip("\r\n"))
+        cues.append((start, end, re.split(r"\\[Nn]", text)))
+    return cues
+
+
+def cues_of(path):
+    lines = read(path)
+    if kind(path) in (".ass", ".ssa"):
+        cues = ass_cues(lines)
+    else:
+        cues = text_cues(lines)
+    if not cues:
+        raise RuntimeError("Found no cues in " + os.path.basename(path))
+    return cues
+
+
+def as_srt(cues):
+    out = []
+    number = 1
+    for start, end, body in cues:
+        out.append("%d\n" % number)
+        out.append("%s --> %s\n" % (from_ms(start, False), from_ms(end, False)))
+        for line in body:
+            out.append(line + "\n")
+        out.append("\n")
+        number = number + 1
+    return out
+
+
+def as_vtt(cues):
+    out = ["WEBVTT\n", "\n"]
+    for start, end, body in cues:
+        out.append("%s --> %s\n" % (from_ms(start, True), from_ms(end, True)))
+        for line in body:
+            out.append(line + "\n")
+        out.append("\n")
+    return out
+
+
+ASS_HEAD = """[Script Info]
+ScriptType: v4.00+
+WrapStyle: 0
+ScaledBorderAndShadow: yes
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
+Style: Default,Arial,20,&H00FFFFFF,&H000000FF,&H00000000,&H00000000,0,0,0,0,100,100,0,0,1,2,0,2,10,10,10,1
+
+[Events]
+Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+SSA_HEAD = """[Script Info]
+ScriptType: v4.00
+
+[V4 Styles]
+Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding
+Style: Default,Arial,20,16777215,255,0,0,0,0,1,2,0,2,10,10,10,0,1
+
+[Events]
+Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+"""
+
+
+def as_ass(cues):
+    out = [ASS_HEAD]
+    for start, end, body in cues:
+        out.append("Dialogue: 0,%s,%s,Default,,0,0,0,,%s\n"
+                   % (from_ms_ass(start), from_ms_ass(end), "\\N".join(body)))
+    return out
+
+
+def as_ssa(cues):
+    out = [SSA_HEAD]
+    for start, end, body in cues:
+        out.append("Dialogue: Marked=0,%s,%s,Default,,0,0,0,,%s\n"
+                   % (from_ms_ass(start), from_ms_ass(end), "\\N".join(body)))
+    return out
+
+
+WRITERS = {".srt": as_srt, ".vtt": as_vtt, ".ass": as_ass, ".ssa": as_ssa}
+
+
+def convert(path, want, drop):
+    if want not in WRITERS:
+        raise RuntimeError("Cannot write that format: " + str(want))
+
+    target = os.path.splitext(path)[0] + want
+    if target == path:
+        raise RuntimeError(os.path.basename(path) + " is " + want + " already")
+
+    cues = cues_of(path)
+    if os.path.exists(target) and not os.path.exists(target + ".bak"):
+        shutil.copy2(target, target + ".bak")
+
+    with open(target + ".part", "w", encoding="utf-8") as file:
+        file.writelines(WRITERS[want](cues))
+    os.replace(target + ".part", target)
+
+    if drop:
+        os.remove(path)
+    return target

--- a/docker/web.py
+++ b/docker/web.py
@@ -87,6 +87,8 @@ def state():
             "waiting": waiting.qsize(),
         },
         "engine": json.loads(setting(conn, "engine", "{}")),
+        "count_embedded": setting(conn, "count_embedded", "0") == "1",
+        "films": films(conn, setting(conn, "count_embedded", "0") == "1"),
         "interval": int(setting(conn, "scan_interval", config["interval"])),
         "excluded": json.loads(setting(conn, "excluded", "[]")),
         "folders": folders(),
@@ -178,6 +180,145 @@ def shift(conn, ids, ms, mode):
     conn.commit()
 
 
+def engine_json(text):
+    for line in reversed(text.splitlines()):
+        line = line.strip()
+        if line.startswith("{"):
+            try:
+                return json.loads(line)
+            except ValueError:
+                pass
+    return {}
+
+
+def inside_library(path):
+    for root in config["roots"]:
+        if path == root or path.startswith(root + os.sep):
+            return True
+    return False
+
+
+def neighbours(conn, ids):
+    found = []
+    for job_id in ids:
+        row = job(conn, job_id)
+        if not row:
+            continue
+        folder = os.path.dirname(row["srt_path"])
+        try:
+            names = sorted(os.listdir(folder))
+        except OSError:
+            continue
+        for name in names:
+            if name.startswith("."):
+                continue
+            if os.path.splitext(name)[1].lower() in config["formats"]:
+                full = os.path.join(folder, name)
+                if full not in found:
+                    found.append(full)
+    found.sort()
+    return found
+
+
+def sync_one(conn, row, reference, mode):
+    target = row["srt_path"]
+    command = [config["lapse"], reference, target, "--json"]
+
+    if mode.startswith("new"):
+        base, ext = os.path.splitext(target)
+        command = command + ["--output", base + ".synced" + ext]
+    if mode == "new" or mode == "overwrite":
+        command.append("--no-backup")
+
+    result = subprocess.run(command, capture_output=True, text=True, timeout=600)
+    values = engine_json(result.stdout or "")
+    if not values:
+        raise RuntimeError((result.stderr or "").strip() or "lapse said nothing")
+
+    written = values.get("output") or target
+    if not values.get("written") or not os.path.exists(written):
+        conn.execute("UPDATE sync_jobs SET status = 'lowconf' WHERE id = ?", (row["id"],))
+        return
+
+    if values.get("verdict") == "solid":
+        status = "done"
+    else:
+        status = "lowconf"
+
+    if written == target:
+        conn.execute(
+            "UPDATE sync_jobs SET offset_ms = ?, confidence = ?, srt_mtime = ?, status = ? WHERE id = ?",
+            (values.get("offset_ms"), values.get("confidence"),
+             os.path.getmtime(written), status, row["id"])
+        )
+    else:
+        note_written(conn, row, written, values.get("offset_ms"))
+
+
+def reference_sync(conn, ids, reference, everything, mode):
+    if not reference:
+        raise RuntimeError("Say which subtitle is already correct")
+    if not inside_library(reference) or not os.path.isfile(reference):
+        raise RuntimeError("No such subtitle in the library: " + reference)
+
+    if everything:
+        folder = os.path.dirname(reference)
+        ids = []
+        for row in conn.execute("SELECT id, srt_path FROM sync_jobs"):
+            if os.path.dirname(row["srt_path"]) == folder:
+                ids.append(row["id"])
+
+    for job_id in ids:
+        row = job(conn, job_id)
+        if row and row["srt_path"] != reference:
+            sync_one(conn, row, reference, mode)
+    conn.commit()
+
+
+def convert(conn, ids, want, drop):
+    for job_id in ids:
+        row = job(conn, job_id)
+        if not row:
+            continue
+        written = subs.convert(row["srt_path"], want, drop)
+        note_written(conn, row, written, row["offset_ms"])
+        if drop:
+            conn.execute("DELETE FROM sync_jobs WHERE id = ?", (job_id,))
+    conn.commit()
+
+
+def films(conn, count_embedded):
+    videos = {}
+    for row in conn.execute("SELECT video_path, status FROM sync_jobs"):
+        if row["video_path"] not in videos:
+            videos[row["video_path"]] = []
+        videos[row["video_path"]].append(row["status"])
+
+    tracks = {}
+    for row in conn.execute("SELECT video_path, tracks FROM video_tracks"):
+        tracks[row["video_path"]] = row["tracks"]
+
+    full = 0
+    part = 0
+    none = 0
+    for video in videos:
+        wanted = len(videos[video])
+        if count_embedded:
+            wanted = wanted + tracks.get(video, 0)
+        ok = 0
+        for status in videos[video]:
+            if status == "done":
+                ok = ok + 1
+        if ok == 0:
+            none = none + 1
+        elif ok >= wanted:
+            full = full + 1
+        else:
+            part = part + 1
+
+    return {"total": len(videos), "full": full, "part": part, "none": none}
+
+
 def queue_translations(conn, ids, language):
     if not language:
         raise RuntimeError("Say which language to translate into")
@@ -217,6 +358,16 @@ def act(path, body):
             return {"path": row["srt_path"], "cues": subs.preview(row["srt_path"])}
         elif path == "/api/shift":
             shift(conn, wanted_ids(body), int(body.get("ms", 0)), output_mode(body))
+        elif path == "/api/neighbours":
+            return {"paths": neighbours(conn, wanted_ids(body))}
+        elif path == "/api/reference":
+            reference_sync(conn, wanted_ids(body), (body.get("reference") or "").strip(),
+                           bool(body.get("everything")), output_mode(body))
+        elif path == "/api/convert":
+            convert(conn, wanted_ids(body), (body.get("format") or "").lower(),
+                    bool(body.get("drop")))
+        elif path == "/api/embedded":
+            save_setting(conn, "count_embedded", "1" if body.get("on") else "0")
         elif path == "/api/pause":
             hold = bool(body.get("paused"))
             save_setting(conn, "paused", "1" if hold else "0")
@@ -298,9 +449,9 @@ class Handler(BaseHTTPRequestHandler):
             self.reply(answer)
 
 
-def start(port, jobs, roots, db_path, lapse, interval, halt):
-    config.update({"jobs": jobs, "roots": roots, "db_path": db_path,
-                   "lapse": lapse, "interval": interval, "halt": halt})
+def start(port, jobs, roots, db_path, lapse, interval, halt, formats):
+    config.update({"jobs": jobs, "roots": roots, "db_path": db_path, "lapse": lapse,
+                   "interval": interval, "halt": halt, "formats": formats})
 
     server = ThreadingHTTPServer(("0.0.0.0", port), Handler)
     server.daemon_threads = True


### PR DESCRIPTION
The status dot in the header is gone, the palette and spacing follow the usual media stack look, and the tables are denser.

Sync to reference lines up every other track in the folder against the one you say is correct, or just the tracks you picked. Convert writes a subtitle out as another format. The line under the tiles counts films rather than subtitle files, and tracks inside the video are left out of that sum unless you ask for them.